### PR TITLE
Improve bookmark attachments and lazy-load feed data on visibility

### DIFF
--- a/client/web/src/components/pc-bookmark-attachment.css
+++ b/client/web/src/components/pc-bookmark-attachment.css
@@ -1,0 +1,21 @@
+pc-bookmark-attachment {
+  display: contents;
+}
+
+.bookmark.h-entry pc-bookmark-attachment-set.hide {
+  display: none;
+}
+
+.bookmark.h-entry pc-bookmark-attachment-set.hide-tabs pc-bookmark-attachment details summary {
+  display: none;
+}
+
+.bookmark.h-entry pc-bookmark-attachment-set.vertical {
+  grid-column: 1 / -1;
+}
+
+.bookmark.h-entry pc-bookmark-attachment-set.vertical pc-bookmark-attachment details summary {
+  margin-left: 0.5em;
+  padding: 0.5em;
+  font-size: 0.9em;
+}

--- a/client/web/src/components/pc-bookmark-attachment.ts
+++ b/client/web/src/components/pc-bookmark-attachment.ts
@@ -1,0 +1,41 @@
+import { LitElement, html, render } from "lit";
+import { PCTabElement, PCTabGroupElement } from "./pc-tab-group";
+
+import "./pc-bookmark-attachment.css";
+
+export class PCBookmarkAttachment extends PCTabElement {
+  disconnectAbortSignal = new AbortController();
+
+  createRenderRoot() {
+    return this;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.disconnectAbortSignal.abort();
+  }
+}
+
+customElements.define("pc-bookmark-attachment", PCBookmarkAttachment);
+
+export class PCBookmarkAttachmentSet extends PCTabGroupElement {
+  disconnectAbortSignal = new AbortController();
+
+  createRenderRoot() {
+    return this;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.disconnectAbortSignal.abort();
+  }
+}
+
+customElements.define("pc-bookmark-attachment-set", PCBookmarkAttachmentSet);

--- a/client/web/src/components/pc-bookmark.css
+++ b/client/web/src/components/pc-bookmark.css
@@ -19,6 +19,15 @@
   grid-column: main;
 }
 
+.bookmark.h-entry > .meta {
+  grid-column: main;
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  column-gap: var(--column-gap);
+  row-gap: calc(var(--column-gap) * 0.75);
+}
+
 .bookmark.h-entry .thumbnail {
   grid-column: thumbnail;
   grid-row: 1 / 3;
@@ -44,15 +53,6 @@
 .bookmark.h-entry .p-name {
   grid-column: main;
   font-size: 1.2em;
-}
-
-.bookmark.h-entry > .meta {
-  grid-column: main;
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
-  column-gap: 1em;
-  row-gap: 1em;
 }
 
 .bookmark.h-entry .href::before {
@@ -110,12 +110,10 @@
   flex-basis: 100%;
 }
 
-/*
 .bookmark.h-entry .p-category::before {
   content: "\1F3F7";
   padding-right: 0.25em;
 }
-*/
 
 .bookmark.h-entry .p-category {
   white-space: nowrap;
@@ -124,6 +122,7 @@
 :root {
   --tag-size: 11px;
 }
+
 .bookmark.h-entry .p-category {
   position: relative;
   background-color: var(--theme-highlighted-bg-color);
@@ -131,6 +130,7 @@
   border-radius: 0px;
   display: inline-block;
 }
+
 .bookmark.h-entry .p-category::before {
   content: "";
   position: absolute;
@@ -142,6 +142,10 @@
   border-top: var(--tag-size) solid transparent;
   border-bottom: var(--tag-size) solid transparent;
   transform: translateY(-50%);
+}
+
+.bookmark.h-entry .p-summary {
+  line-height: 1.5em;
 }
 
 .bookmark.h-entry .actions {
@@ -170,8 +174,10 @@
 .bookmark.h-entry .actions a {
   border: 1px solid var(--theme-shadow-color);
   border-radius: 4px;
+  font-size: 0.9em;
   text-decoration: none;
-  padding: 0.125em 0.5em;
+  text-align: center;
+  padding: 0.125em 0.25em;
   background: var(--theme-highlighted-bg-color);
   opacity: 0.8;
   box-shadow: 1px 1px 2px 0px var(--theme-shadow-color);
@@ -181,55 +187,12 @@
   opacity: 1;
 }
 
-.bookmark.h-entry .content-selector {
-  grid-column: thumbnail;
-  grid-row: 3;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  border-right: 1px solid var(--theme-highlighted-bg-color);
-}
-
-.bookmark.h-entry .content-selector label {
-  white-space: nowrap;
+pc-bookmark-attachment section iframe {
   display: block;
+  border: none;
+  padding: none;
+  margin: none;
   width: 100%;
-  text-align: right;
-}
-
-.bookmark.h-entry .content-selector input[type=radio] {
-  display: none;
-}
-
-.bookmark.h-entry .content-selector label > span {
-  cursor: pointer;
-  user-select: none;
-  display: block;
-  padding: 0.25em 0.5em 0.25em 0.5em;
-}
-
-.bookmark.h-entry .content-selector label > input:checked ~ span {
-  background: var(--theme-highlighted-bg-color);
-  border-start-start-radius: 0.5em;
-  border-end-start-radius: 0.5em;
-}
-
-.bookmark.h-entry .content-views {
-  flex-grow: 1;
-  display: flex;
-  flex-direction: column;
-  row-gap: calc(var(--row-gap) / 4);
-}
-
-.bookmark.h-entry .content {
-  margin-left: -1px;
-  padding: 0.25em 0 0.25em 1em;
-  width: 100%;
-  border-left: 1px solid var(--theme-highlighted-bg-color);
-  margin-left: calc(-1px - var(--column-gap));
-  display: none;
-}
-
-.bookmark.h-entry .content.selected {
-  display: block;
+  /* TODO: rig up something to auto-adjust iframe height */
+  height: 300px;
 }

--- a/client/web/src/components/pc-bookmark.ts
+++ b/client/web/src/components/pc-bookmark.ts
@@ -4,16 +4,13 @@ import linkSvg from "@common/svg/link";
 import "./pc-bookmark.css";
 
 export default class PCBookmarkElement extends LitElement {
-  hiddenContentViews?: string[];
-  defaultSelectedContentView?: string;
-  selectedContentView?: string;
   bookmark?: Object;
+  disconnectAbortSignal?: AbortController;
+  elActions?: HTMLElement | null;
+  elAttachments?: HTMLElement | null;
 
   static get properties() {
     return {
-      hiddenContentViews: { type: Array },
-      defaultSelectedContentView: { type: String },
-      selectedContentView: { type: String, attribute: true, reflect: true },
       bookmark: {
         type: Object,
         attribute: true,
@@ -32,110 +29,47 @@ export default class PCBookmarkElement extends LitElement {
     };
   }
 
-  disconnectAbortSignal = new AbortController();
-
   createRenderRoot() {
     return this;
   }
 
   connectedCallback() {
-    super.connectedCallback();
+    this.disconnectAbortSignal = new AbortController();
+    this.elAttachments = this.querySelector("pc-bookmark-attachment-set");
+    this.elActions = this.querySelector(".actions");
 
-    this.selectDefaultContentView();
-    this.enhanceContentSelector();
+    super.connectedCallback();
     this.enhanceThumbnail();
   }
 
   disconnectedCallback() {
-    super.disconnectedCallback();    
-    this.disconnectAbortSignal.abort();
+    super.disconnectedCallback();
+    this.disconnectAbortSignal!.abort();
+  }
+
+  extendedActionsTemplate = () => html`
+    ${
+      this.elAttachments &&
+      html`<a @click=${this.toggleAttachments.bind(this)}>${
+        this.elAttachments.classList.contains("hide")
+          ? html`&#x25BC;`
+          : html`&#x25B2;`
+      }</a>`
+    }
+  `;
+
+  toggleAttachments() {
+    if (!this.elAttachments) return;
+    this.elAttachments.classList.toggle("hide");
+    this.requestUpdate();
   }
 
   render() {
-    if (this.contentSelector) {
-      render(this.contentSelectorTemplate(this), this.contentSelector);
-    }
+    if (this.elActions) render(this.extendedActionsTemplate(), this.elActions);
   }
 
   get url() {
     return this.querySelector(".u-url")?.getAttribute("href");
-  }
-
-  contentSelector?: HTMLElement | null;
-
-  contentSelectorTemplate = (props: this) => {
-    const selectableViews = this.contentViews.filter(
-      ([name, _contentEl]) =>
-        name && !(this.hiddenContentViews || []).includes(name)
-    );
-    if (selectableViews.length === 1) return null;
-    return html`
-      ${selectableViews.map(
-        ([name, contentEl]) => html`
-          <label>
-            <input type="radio" name="content" value="${name}"
-              ?checked=${name === props.selectedContentView} />
-            <span>${contentEl.dataset.title || name}</span>
-          </label>      
-        `
-      )}
-    `;
-  };
-
-  enhanceContentSelector() {
-    const { signal } = this.disconnectAbortSignal;
-    this.contentSelector = this.querySelector<HTMLElement>(".content-selector");
-    if (this.contentSelector) {
-      this.contentSelector.addEventListener(
-        "change",
-        (ev) => {
-          const { target } = ev;
-          if (target instanceof HTMLInputElement && target.name == "content") {
-            const { value: selectedName } = target;
-            this.selectContentView(selectedName, false);
-          }
-        },
-        { signal }
-      );
-    }
-  }
-
-  get contentViewSelectors() {
-    const els = this.querySelectorAll<HTMLInputElement>(
-      ".content-selector input"
-    );
-    const hiddenContentViews = this.hiddenContentViews || [];
-    if (els.length) {
-      return Array.from(els)
-        .map((el) => [el.value, el] as const)
-        .filter(([name, el]) => !hiddenContentViews.includes(name));
-    }
-    return [];
-  }
-
-  get contentViews() {
-    const els = this.querySelectorAll<HTMLElement>(".content-views .content");
-    if (els.length) {
-      return Array.from(els).map((el) => [el.dataset["name"], el] as const);
-    }
-    return [];
-  }
-
-  selectContentView(selectedName: string, updateChecked: boolean = true) {
-    this.selectedContentView = selectedName;
-    for (const [name, el] of this.contentViews) {
-      el.classList[name === selectedName ? "add" : "remove"]("selected");
-    }
-  }
-
-  selectDefaultContentView() {
-    if (this.contentViews?.length) {
-      const firstViewName = this.contentViews[0][0];
-      const defaultSelected = /* this.defaultSelectedContentView || */ firstViewName;
-      if (defaultSelected) {
-        this.selectContentView(defaultSelected, true);
-      }
-    }
   }
 
   enhanceThumbnail() {
@@ -144,16 +78,18 @@ export default class PCBookmarkElement extends LitElement {
       ".bookmark-thumbnail img"
     );
     if (thumbnail) {
-      thumbnail.addEventListener("load", () => {});
-
-      thumbnail.addEventListener("error", () => {
-        const { parentElement } = thumbnail;
-        if (parentElement) {
-          // Replace broken image with muted red link SVG default
-          parentElement.innerHTML = linkSvg();
-          parentElement.style.color = "rgba(255, 128, 128, 0.2)";
-        }
-      });
+      thumbnail.addEventListener(
+        "error",
+        () => {
+          const { parentElement } = thumbnail;
+          if (parentElement) {
+            // Replace broken image with muted red link SVG default
+            parentElement.innerHTML = linkSvg();
+            parentElement.style.color = "rgba(255, 128, 128, 0.2)";
+          }
+        },
+        { signal: this.disconnectAbortSignal!.signal }
+      );
     }
   }
 }

--- a/client/web/src/components/pc-tab-group.css
+++ b/client/web/src/components/pc-tab-group.css
@@ -1,0 +1,66 @@
+.pc-tab-group {
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  grid-template-rows: [tabs-start] auto [tabs-end content-start] 1fr [content-end];
+}
+
+.pc-tab-group details {
+  display: contents;
+}
+
+.pc-tab-group details summary {
+  grid-row: tabs;
+  user-select: none;
+  cursor: pointer;
+  list-style: none;
+  padding: 0.5em 0.25em 0.25em 0.25em;
+  margin: 0 0.25em;
+  text-align: center;
+  border: 1px solid var(--theme-highlighted-bg-color);
+  border-start-start-radius: 0.5em;
+  border-start-end-radius: 0.5em;
+}
+
+.pc-tab-group details summary::-webkit-details-marker {
+  display: none;
+}
+
+.pc-tab-group details[open] summary {
+  background-color: var(--theme-highlighted-bg-color);
+}
+
+.pc-tab-group details summary + section {
+  border-top: 1px solid var(--theme-highlighted-bg-color);
+  margin: -1px 0 0 0;
+  padding: 0 var(--column-gap);
+  grid-column-start: 1;
+  grid-column-end: -1;
+  grid-row: content;
+}
+
+.pc-tab-group.vertical {
+  display: grid;
+  grid-template-columns: [tabs] var(--thumbnail-size) [content-start] auto [content-end];
+  grid-template-rows: auto
+}
+
+.pc-tab-group.vertical details summary {
+  grid-row: unset;
+  grid-column: tabs;
+  padding: 0.5em;
+  margin: 0 0 0.25em 0;
+  text-align: right;
+  border-start-start-radius: unset;
+  border-start-end-radius: unset;
+  border-start-start-radius: 0.5em;
+  border-end-start-radius: 0.5em;
+}
+
+.pc-tab-group.vertical details summary + section {
+  border-top: unset;
+  border-left: 1px solid var(--theme-highlighted-bg-color);
+  margin: 0 0 0 -1px;
+  grid-column: content / -1;
+  grid-row: 1 / 10;
+  display: block;
+}

--- a/client/web/src/components/pc-tab-group.ts
+++ b/client/web/src/components/pc-tab-group.ts
@@ -1,0 +1,72 @@
+import { LitElement, html, render } from "lit";
+
+import "./pc-tab-group.css";
+
+export class PCTabGroupElement extends LitElement {
+  disconnectAbortSignal?: AbortController;
+
+  createRenderRoot() {
+    return this;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.disconnectAbortSignal = new AbortController();
+    // HACK: this component's probably getting subclassed, so here's a
+    // cheap way to inherit styles
+    this.classList.add("pc-tab-group");
+    // TODO: can drop this if/when <details name=""> is supported everywhere
+    this.applyMutuallyExclusiveDetailsOpen();
+  }
+
+  applyMutuallyExclusiveDetailsOpen() {
+    // TODO: move this to a reusable component or utility function?
+    const { signal } = this.disconnectAbortSignal!;
+    this.addEventListener(
+      "click",
+      (ev) => {
+        const { target } = ev;
+        // HACK: wish there were an HTMLSummaryElement for type-checking
+        if (target instanceof HTMLElement && /summary/i.test(target.tagName)) {
+          const details = target.closest("details");
+          if (details) {
+            const allDetails = this.querySelectorAll("details");
+            for (const otherDetails of allDetails) {
+              if (otherDetails !== details && otherDetails.open) {
+                otherDetails.open = false;
+              }
+            }
+          }
+        }
+      },
+      { signal }
+    );
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.disconnectAbortSignal!.abort();
+  }
+}
+
+customElements.define("pc-tab-group", PCTabGroupElement);
+
+export class PCTabElement extends LitElement {
+  disconnectAbortSignal?: AbortController;
+
+  createRenderRoot() {
+    return this;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.disconnectAbortSignal = new AbortController();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.disconnectAbortSignal!.abort();
+  }
+}
+
+customElements.define("pc-tab", PCTabElement);

--- a/client/web/src/index.ts
+++ b/client/web/src/index.ts
@@ -2,9 +2,11 @@ import "./index.css";
 
 import "./components/details-closer.ts";
 import "./components/theme-selector.ts";
+import "./components/pc-tab-group.ts";
 import "./components/pc-bookmark.ts";
 import "./components/pc-bookmark-list.ts";
 import "./components/pc-bookmark-form.ts";
+import "./components/pc-bookmark-attachment.ts";
 import "./components/pc-feed.ts";
 
 import "./css/mobile-overrides.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "ajv-errors": "^3.0.0",
         "axios": "^1.7.7",
         "browserless": "^10.6.0",
+        "classnames": "^2.5.1",
         "commander": "^12.1.0",
         "common": "./common",
         "convict": "^6.2.4",
@@ -3264,6 +3265,11 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:client:web": "tsc --project client/web/tsconfig.json --noEmit",
     "test": "glob -c \"tsx --tsconfig ./server/tsconfig.json --no-warnings --test\" \"./server/**/*.test.ts\"",
     "test:watch": "glob -c \"tsx --tsconfig ./server/tsconfig.json --no-warnings --watch --test\" \"./server/**/*.test.ts\"",
-    "dev": "npm-run-all --parallel dev:serve test:watch build:watch",
+    "dev": "npm-run-all --parallel dev:serve build:watch",
     "dev:serve": "nodemon --watch server --ext 'js,ts' --exec 'tsx  --tsconfig ./server/tsconfig.json -- ./server/index.ts --force-pretty-logs serve'",
     "manage": "tsx --tsconfig ./server/tsconfig.json ./server/index.ts",
     "migrate": "npm run manage db migrate"
@@ -40,6 +40,7 @@
     "ajv-errors": "^3.0.0",
     "axios": "^1.7.7",
     "browserless": "^10.6.0",
+    "classnames": "^2.5.1",
     "commander": "^12.1.0",
     "common": "./common",
     "convict": "^6.2.4",

--- a/server/web/templates/partials/bookmark.ts
+++ b/server/web/templates/partials/bookmark.ts
@@ -1,6 +1,7 @@
+import classNames from "classnames";
 import { BookmarkWithPermissions } from "../../../services/bookmarks";
 import { Profile } from "../../../services/profiles";
-import { html } from "../../utils/html";
+import { html, TemplateContent } from "../../utils/html";
 import linkSvg from "@common/svg/link";
 
 export interface Props {
@@ -8,14 +9,13 @@ export interface Props {
   profile: Profile;
   readOnly?: boolean;
   hideAuthor?: boolean;
+  showAttachments?: string[];
+  openAttachment?: string;
 }
 
-export default ({
-  bookmark,
-  profile,
-  readOnly = false,
-  hideAuthor = false,
-}: Props) => {
+export default (props: Props) => {
+  const { bookmark, profile, readOnly = false, hideAuthor = false } = props;
+
   let host;
   try {
     const url = new URL(bookmark.href);
@@ -29,34 +29,29 @@ export default ({
   );
 
   const created = new Date(bookmark.created!);
+
   const unfurl = bookmark.meta?.unfurl;
-  const iframeUrl =
-    unfurl?.iframe &&
-    `data:text/html;base64,${Buffer.from(unfurl?.iframe).toString("base64")}`;
-  const feedUrl = bookmark.meta?.unfurl?.feed;
+
   const thumbnailImage = unfurl?.image
     ? html`<img src="${unfurl.image}" />`
     : linkSvg;
 
   return html`
-    <pc-bookmark
-      bookmark="${bookmarkEncoded}"
-      hiddenContentViews="${JSON.stringify(["unfurl"])}"
-      defaultSelectedContentView="extended"
-    >
-      <div class="bookmark h-entry">    
+    <pc-bookmark bookmark="${bookmarkEncoded}">
+      <section class="bookmark h-entry">
+
         <a class="thumbnail" href="${bookmark.href}">${thumbnailImage}</a>
 
-        ${
-          !readOnly &&
-          bookmark.canEdit &&
-          html`
-          <div class="actions">
-            <a href="/bookmarks/${bookmark.id}/edit">Edit</a>
-            <a href="/bookmarks/${bookmark.id}/delete">Delete</a>
-          </div>
-        `
-        }
+        <div class="actions">
+          ${
+            !readOnly &&
+            bookmark.canEdit &&
+            html`
+              <a href="/bookmarks/${bookmark.id}/edit">Edit</a>
+              <a href="/bookmarks/${bookmark.id}/delete">Delete</a>
+          `
+          }
+        </div>
 
         <a class="p-name u-url" href="${bookmark.href}">${bookmark.title}</a>
 
@@ -68,10 +63,10 @@ export default ({
           ${
             !hideAuthor &&
             html`
-            <a class="p-author" href="/u/${profile.username}">
-              ${profile.username}
-            </a>
-          `
+              <a class="p-author" href="/u/${profile.username}">
+                ${profile.username}
+              </a>
+            `
           }
 
           <time
@@ -101,50 +96,129 @@ export default ({
           }
         </div>
 
-        <form class="content-selector">
-          <!-- populated by component -->
-        </form>
+        ${buildAttachments(props)}
 
-        <section class="content-views">
-          ${
-            bookmark.extended &&
-            html`
-              <section class="content" data-name="extended" data-title="Notes">
-                <section class="p-summary">${bookmark.extended}</section>
-              </section>
-            `
-          }
-          ${
-            feedUrl &&
-            html`
-              <section class="content" data-name="feed" data-title="Feed">
-                <pc-feed url="${feedUrl}" />
-              </section>
-            `
-          }
-          ${
-            iframeUrl &&
-            html`
-              <section class="content" data-name="iframe" data-title="Embed">
-                <iframe
-                  style="width: 100%"
-                  width="400"
-                  height="400"
-                  src="${iframeUrl}"
-                ></iframe>
-              </section>
-            `
-          }
-          ${
-            bookmark.meta?.unfurl &&
-            html`
-              <section class="content" data-name="unfurl" data-title="Unfurl">
-                <textarea rows="15" style="width: 90%">${bookmark.meta?.unfurl}</textarea>
-              </section>
-            `
-          }
-        </section>
-      </div>
+      </section>
+
     </pc-bookmark>
   `;
+};
+
+function buildAttachments({
+  bookmark,
+  openAttachment: openAttachmentIn,
+  showAttachments = [],
+}: Props) {
+  // Filter out any attachments that don't have a formatter
+  const validShowAttachments = showAttachments.filter(
+    (name) => attachmentFormatters[name]
+  );
+  if (validShowAttachments.length === 0) return;
+
+  // Determine which attachment to open - default to the first shown
+  const openAttachment =
+    openAttachmentIn && validShowAttachments.includes(openAttachmentIn)
+      ? openAttachmentIn
+      : validShowAttachments[0];
+
+  // Hide attachments by default, unless one proves to be open
+  let hideAttachments = true;
+
+  const attachments = [];
+  for (const name of validShowAttachments) {
+    // Attempt to find a formatter for the named attachment
+    const formatter = attachmentFormatters[name];
+    if (!formatter) continue;
+
+    // Attempt to format the attachment, skipping if no content
+    const props = formatter(bookmark);
+    if (!props) continue;
+
+    // If the attachment has output and is the open attachment, show attachments
+    if (name === openAttachment) hideAttachments = false;
+
+    // Finally, render the attachment and add it to the list
+    attachments.push(
+      baseAttachmentTemplate({
+        open: name === openAttachment,
+        ...props,
+      })
+    );
+  }
+
+  // If no attachments, return early
+  if (attachments.length === 0) return;
+
+  // Hide attachment tabs if there is only one attachment
+  const hideAttachmentTabs = attachments.length <= 1;
+
+  return html`
+    <pc-bookmark-attachment-set class="${classNames("vertical", {
+      "hide-tabs": hideAttachmentTabs,
+      hide: hideAttachments,
+    })}">
+      ${attachments}
+    </pc-bookmark-attachment-set>
+  `;
+}
+
+type AttachmentProps = {
+  name: string;
+  title: string;
+  open: boolean;
+  content: TemplateContent;
+};
+
+const baseAttachmentTemplate = (props: AttachmentProps) => html`
+  <pc-bookmark-attachment name="${props.name}">
+    <details ${props.open ? "open" : ""}>
+      <summary>${props.title}</summary>
+      <section>${props.content}</section>
+    </details>
+  </pc-bookmark-attachment>
+`;
+
+type AttachmentFormatter = (
+  bookmark: BookmarkWithPermissions
+) => Omit<AttachmentProps, "open"> | undefined;
+
+const attachmentFormatters: Record<string, AttachmentFormatter> = {
+  notes: (bookmark) => {
+    if (bookmark.extended)
+      return {
+        name: "notes",
+        title: "Notes",
+        content: html`<section class="p-summary">${bookmark.extended}</section>`,
+      };
+  },
+  feed: (bookmark) => {
+    const feedUrl = bookmark.meta?.unfurl?.feed;
+    if (feedUrl)
+      return {
+        name: "feed",
+        title: "Feed",
+        content: html`<pc-feed url="${feedUrl}" />`,
+      };
+  },
+  embed: (bookmark) => {
+    const unfurl = bookmark.meta?.unfurl;
+    const iframeUrl =
+      unfurl?.iframe &&
+      `data:text/html;base64,${Buffer.from(unfurl?.iframe).toString("base64")}`;
+    if (iframeUrl)
+      return {
+        name: "embed",
+        title: "Embed",
+        content: html`<iframe frameborder="0" src="${iframeUrl}"></iframe>`,
+      };
+  },
+  unfurl: (bookmark) => {
+    const unfurl = bookmark.meta?.unfurl;
+    if (unfurl)
+      return {
+        name: "unfurl",
+        title: "Unfurl",
+        content: html`<textarea rows="15" style="width: 90%">${unfurl}</textarea>`,
+      };
+  },
 };

--- a/server/web/templates/partials/bookmarkList.ts
+++ b/server/web/templates/partials/bookmarkList.ts
@@ -6,15 +6,30 @@ import partialBookmark from "./bookmark";
 export interface Props {
   bookmarks: BookmarkWithPermissions[];
   profile: Profile;
+  hideAuthor?: boolean;
+  showAttachments?: string[];
+  openAttachment?: string;
 }
 
-export default ({ bookmarks, profile }: Props) => html`
+export default ({
+  bookmarks,
+  profile,
+  hideAuthor = true,
+  showAttachments = ["notes", "feed", "embed", "unfurl"],
+  openAttachment,
+}: Props) => html`
   <pc-bookmark-list>
     <ul class="bookmarks h-feed">
       ${bookmarks.map(
         (bookmark) =>
           html`<li>
-            ${partialBookmark({ bookmark, profile, hideAuthor: true })}
+            ${partialBookmark({
+              bookmark,
+              profile,
+              hideAuthor,
+              showAttachments,
+              openAttachment,
+            })}
           </li>`
       )}
     </ul>

--- a/server/web/templates/profile/index.ts
+++ b/server/web/templates/profile/index.ts
@@ -9,6 +9,8 @@ import partialPaginator from "../partials/paginator";
 
 export interface Props extends LayoutProps {
   profile: Profile;
+  showAttachments?: string[];
+  openAttachment?: string;
   bookmarks: BookmarkWithPermissions[];
   tagCounts: TagCount[];
   limit: number;
@@ -19,6 +21,8 @@ export interface Props extends LayoutProps {
 export default ({
   profile,
   bookmarks,
+  showAttachments = ["notes", "feed", "embed", "unfurl"],
+  openAttachment,
   tagCounts,
   total,
   limit,
@@ -31,15 +35,22 @@ export default ({
     content: html`
       <section class="profile">
         <section class="bookmarks">
-          ${partialPaginator({ total, limit, offset })}
-          ${partialBookmarkList({ bookmarks, profile })}
-          ${partialPaginator({ total, limit, offset })}
+          ${partialPaginator({ total, limit, offset, showAttachments, openAttachment })}
+          ${partialBookmarkList({
+            bookmarks,
+            profile,
+            showAttachments,
+            openAttachment,
+          })}
+          ${partialPaginator({ total, limit, offset, showAttachments, openAttachment })}
         </section>
         <section class="tagCounts">
           <ul>
-            ${tagCounts.map(({ name, count }) => html`
+            ${tagCounts.map(
+              ({ name, count }) => html`
               <li><a href="/u/${profile.username}/t/${name}">${name} (${count})</a></li>
-            `)}
+            `
+            )}
           </ul>
         </section>
       </section>


### PR DESCRIPTION
- rework bookmark attachments to use styled detail elements

- only load feed data when pc-feed is visible

- implement GET-baed feed batch fetch with read-only queries

- add pc-tab-group and pc-tab components

- implement ?open and ?show parmeters for controlling attachments

- preserve attachment control parameters in pagination links

fixes https://github.com/lmorchard/pebbling-club/issues/154

fixes https://github.com/lmorchard/pebbling-club/issues/153