### PR TITLE
56 simple job queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "common": "./common",
         "convict": "^6.2.4",
         "cookie-parser": "^1.4.6",
+        "cron-parser": "^4.9.0",
         "csurf": "^1.11.0",
         "csv": "^6.3.10",
         "dotenv": "^16.4.5",
@@ -4103,6 +4104,18 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7340,6 +7353,15 @@
       "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
       "dependencies": {
         "es5-ext": "~0.10.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "common": "./common",
     "convict": "^6.2.4",
     "cookie-parser": "^1.4.6",
+    "cron-parser": "^4.9.0",
     "csurf": "^1.11.0",
     "csv": "^6.3.10",
     "dotenv": "^16.4.5",

--- a/server/app/config.ts
+++ b/server/app/config.ts
@@ -10,9 +10,11 @@ import { configSchema as repositorySqliteConfigSchema } from "../repositories/sq
 import { configSchema as repositorySqliteFeedsConfigSchema } from "../repositories/sqlite/feeds/index";
 import { configSchema as repositorySqliteFetchConfigSchema } from "../repositories/sqlite/fetch/index";
 import { configSchema as repositorySqliteUnfurlConfigSchema } from "../repositories/sqlite/unfurl/index";
+import { configSchema as repositorySqliteJobsConfigSchema } from "../repositories/sqlite/jobs/index";
 import { configSchema as fetchConfigSchema } from "../services/fetch";
 import { configSchema as feedsConfigSchema } from "../services/feeds";
 import { configSchema as unfurlConfigSchema } from "../services/unfurl";
+import { configSchema as jobsConfigSchema } from "../services/jobs";
 
 // HACK: Hardcoded assemblage of all configuration schemas, would be nice
 // if was dynamic at run-time
@@ -23,9 +25,11 @@ export const configSchema = {
   ...repositorySqliteFeedsConfigSchema,
   ...repositorySqliteFetchConfigSchema,
   ...repositorySqliteUnfurlConfigSchema,
+  ...repositorySqliteJobsConfigSchema,
   ...fetchConfigSchema,
   ...feedsConfigSchema,
   ...unfurlConfigSchema,
+  ...jobsConfigSchema,
 } as const;
 
 // Load up the base config from environment and schema

--- a/server/cli/db.ts
+++ b/server/cli/db.ts
@@ -5,18 +5,26 @@ import { SqliteRepository } from "../repositories/sqlite/main";
 import SqliteFeedsRepository from "../repositories/sqlite/feeds";
 import SqliteFetchRepository from "../repositories/sqlite/fetch";
 import SqliteUnfurlRepository from "../repositories/sqlite/unfurl";
+import SqliteJobsRepository from "../repositories/sqlite/jobs";
 
 export type IAppRequirements = {
   repository: SqliteRepository;
   feedsRepository: SqliteFeedsRepository;
   fetchRepository: SqliteFetchRepository;
   unfurlRepository: SqliteUnfurlRepository;
+  jobsRepository: SqliteJobsRepository;
 };
 
 export default class CliFeeds extends CliAppModule<IAppRequirements> {
   async initCli(program: Command) {
     const { log, app } = this;
-    const { repository, feedsRepository, fetchRepository, unfurlRepository } = app;
+    const {
+      repository,
+      feedsRepository,
+      fetchRepository,
+      unfurlRepository,
+      jobsRepository,
+    } = app;
 
     const dbProgram = program
       .command("db")
@@ -41,6 +49,10 @@ export default class CliFeeds extends CliAppModule<IAppRequirements> {
         log.info({
           msg: "migrate unfurl db",
           result: await unfurlRepository.connection.migrate.latest(),
+        });
+        log.info({
+          msg: "migrate jobs db",
+          result: await jobsRepository.connection.migrate.latest(),
         });
       });
 
@@ -67,5 +79,11 @@ export default class CliFeeds extends CliAppModule<IAppRequirements> {
       .description("unfurl repository commands");
 
     buildKnexProgram(unfurlDbProgram, unfurlRepository.connection, log);
+
+    const jobsDbProgram = dbProgram
+      .command("jobs")
+      .description("jobs repository commands");
+
+    buildKnexProgram(jobsDbProgram, jobsRepository.connection, log);
   }
 }

--- a/server/cli/feeds.ts
+++ b/server/cli/feeds.ts
@@ -47,7 +47,8 @@ export default class CliFeeds extends CliAppModule<IAppRequirements> {
     const { app, log } = this;
     const { feeds } = app;
 
-    await feeds.updateAll({ forceFetch: options.force });
+    //await feeds.updateAll({ forceFetch: options.force });
+    await feeds.updateAllWithJobQueue({ forceFetch: options.force });
   }
 
   async commandGet(url: string, options: { force?: boolean }) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,14 +23,19 @@ import CliFeeds from "./cli/feeds";
 import CliDb from "./cli/db";
 import CliFetch from "./cli/fetch";
 import CliUnfurl from "./services/unfurl/cli";
+import CliJobs from "./services/jobs/cli";
+import SqliteJobsRepository from "./repositories/sqlite/jobs";
+import { JobsService } from "./services/jobs";
 
 export class MainCliApp extends BaseCliApp {
   // TODO: make repository instances switchable via config
   feedsRepository = new SqliteFeedsRepository(this);
   fetchRepository = new SqliteFetchRepository(this);
   unfurlRepository = new SqliteUnfurlRepository(this);
+  jobsRepository = new SqliteJobsRepository(this);
   repository = new SqliteRepository(this);
 
+  jobs = new JobsService(this);
   passwords = new PasswordService(this);
   profiles = new ProfileService(this);
   bookmarks = new BookmarksService(this);
@@ -49,7 +54,10 @@ export class MainCliApp extends BaseCliApp {
       this.feedsRepository,
       this.fetchRepository,
       this.unfurlRepository,
+      this.jobsRepository,
       this.repository,
+
+      this.jobs,
       this.passwords,
       this.profiles,
       this.bookmarks,
@@ -58,13 +66,15 @@ export class MainCliApp extends BaseCliApp {
       this.feeds,
       this.unfurl,
       this.webServer,
+      
       new CliDb(this),
       new CliProfiles(this),
       new CliImport(this),
       new CliBookmarks(this),
       new CliFeeds(this),
       new CliFetch(this),
-      new CliUnfurl(this)
+      new CliUnfurl(this),
+      new CliJobs(this),
     );
   }
 }

--- a/server/repositories/sqlite/base.ts
+++ b/server/repositories/sqlite/base.ts
@@ -41,7 +41,7 @@ export default class BaseSqliteKnexRepository<
       // Failed to access database, assume it doesn't exist
       // TODO: check if it's actually a permission problem
       log.trace({ msg: "sqlite database access failed", err });
-      log.info({
+      log.trace({
         msg: "initializing sqlite database",
         filename: connectionOptions.filename,
       });
@@ -64,6 +64,16 @@ export default class BaseSqliteKnexRepository<
         "migrations"
       )
     );
+  }
+
+  _buildKnexConnectionOptions(databaseNameConfig: string): Knex.Knex.Config["connection"] {
+    const { config } = this.app;
+    return {
+      filename: path.join(
+        config.get("sqliteDatabasePath"),
+        config.get(databaseNameConfig),
+      ),
+    };
   }
 
   get connection() {

--- a/server/repositories/sqlite/jobs/index.ts
+++ b/server/repositories/sqlite/jobs/index.ts
@@ -1,0 +1,316 @@
+import { v4 as uuid } from "uuid";
+import { IKnexConnectionOptions, IKnexRepository } from "../../knex";
+import BaseSqliteKnexRepository from "../base";
+import Knex from "knex";
+import { BaseJobScheduleModel, IJobsRepository } from "../../../services/jobs";
+import {
+  JobModel,
+  JobModelNew,
+  JobOptions,
+  JobPayload,
+  JobResult,
+  JobState,
+  JobStatus,
+  JobScheduleModel,
+} from "@/services/jobs/types";
+
+export const configSchema = {
+  sqliteJobsDatabaseName: {
+    doc: "Filename for sqlite3 jobs database",
+    env: "SQLITE_JOBS_FILENAME",
+    format: String,
+    default: "jobs.sqlite3",
+  },
+} as const;
+
+export default class SqliteJobsRepository
+  extends BaseSqliteKnexRepository
+  implements IJobsRepository, IKnexRepository, IKnexConnectionOptions
+{
+  get migrationsDirectory() {
+    return this._resolveMigrationsDirectory("jobs");
+  }
+
+  knexConnectionOptions(): Knex.Knex.Config["connection"] {
+    return this._buildKnexConnectionOptions("sqliteJobsDatabaseName");
+  }
+
+  async addJob(jobs: JobModelNew[]): Promise<string[]> {
+    const results: string[] = [];
+    await this.enqueue(() =>
+      this.connection.transaction(async (trx) => {
+        for (const job of jobs) {
+          const { name, payload, options } = job;
+
+          // Tried finding a way to leave deduplicationId as null, but it
+          // seems simplest to generate a unique one if not provided.
+          const deduplicationId = options?.deduplication?.id || uuid();
+
+          let deferUntil = options?.deferUntil;
+          if (options?.delay) {
+            const delay = options.delay;
+            if (deferUntil) {
+              deferUntil += delay;
+            } else {
+              deferUntil = Date.now() + delay;
+            }
+          }
+
+          const toInsert: Record<string, any> = {
+            name,
+            options: JSON.stringify(options),
+            payload: JSON.stringify(payload),
+            state: JobState.Pending,
+            deduplicationId,
+            deferUntil,
+          };
+          const result = await trx("Jobs")
+            .insert(toInsert)
+            .onConflict("deduplicationId")
+            // HACK: this should essentially be a no-op which still returns the ID
+            .merge({ deduplicationId })
+            .returning("id");
+          results.push(result[0].id);
+        }
+      })
+    );
+    return results;
+  }
+
+  async listJobs(
+    options: {
+      name?: string;
+      limit?: number;
+      offset?: number;
+    } = {}
+  ): Promise<JobModel[]> {
+    const { name, limit, offset } = options;
+    const query = this.connection("Jobs");
+    if (name) query.where({ name });
+    if (limit) query.limit(limit);
+    if (offset) query.offset(offset);
+    const results = await query;
+    return results.map((row) => SqliteJobModel.fromRow(row));
+  }
+
+  async fetchJobById(id: string): Promise<JobModel | undefined> {
+    const row = await this.connection("Jobs").where({ id }).first();
+    return row && SqliteJobModel.fromRow(row);
+  }
+
+  async reserveJob(jobNames?: string[]): Promise<JobModel | undefined> {
+    const reservation = uuid();
+    const now = Date.now();
+
+    // Reserve the highest priority, newest, unreserved, pending job
+    // using a queued write to help ensure serialization. Use the returning
+    // clause to get the job details.
+    const result = await this.enqueue(async () =>
+      this.connection("Jobs")
+        .where("rowid", (q: Knex.Knex.QueryBuilder) =>
+          q
+            .select("rowid")
+            .from("Jobs")
+            .whereNull("reservation")
+            .andWhere("state", JobState.Pending)
+            .andWhere((q) =>
+              q.whereNull("deferUntil").orWhere("deferUntil", "<=", now)
+            )
+            .modify((q) => {
+              if (jobNames) q.whereIn("name", jobNames);
+            })
+            .orderBy([
+              { column: "priority", order: "desc" },
+              { column: "createdAt", order: "desc" },
+            ])
+            .limit(1)
+        )
+        .update({
+          reservation,
+          deduplicationId: reservation,
+          state: JobState.Reserved,
+        })
+        .returning("*")
+    );
+
+    return result && result[0] && SqliteJobModel.fromRow(result[0]);
+  }
+
+  async updateJob<Result extends JobResult>({
+    id,
+    state,
+    status,
+    result,
+  }: {
+    id: string;
+    state?: JobState;
+    status?: JobStatus;
+    result?: Result;
+  }): Promise<void> {
+    await this.enqueue(async () => {
+      const { connection: conn } = this;
+      const toUpdate: Record<string, any> = {};
+      if (state) toUpdate["state"] = state;
+      if (status) {
+        toUpdate["status"] = conn.raw(
+          "json_patch(iif(json_valid(status), status, '{}'), :status)",
+          { status: JSON.stringify(status) }
+        );
+      }
+      if (result) toUpdate["result"] = JSON.stringify(result);
+
+      return await conn("Jobs").update(toUpdate).where({ id });
+    });
+  }
+
+  async retryJob(job: JobModel) {
+    const { id, options = {} } = job;
+
+    const attempts = options.attempts || 0;
+    if (attempts < 1) return;
+
+    // TODO: record failures for each attempt?
+
+    await this.enqueue(() =>
+      this.connection("Jobs")
+        .update({
+          state: JobState.Pending,
+          reservation: null,
+          options: JSON.stringify({
+            ...options,
+            attempts: attempts - 1,
+          }),
+        })
+        .where({ id })
+    );
+  }
+
+  async purgeResolvedJobs(): Promise<void> {
+    await this.enqueue(() =>
+      this.connection("Jobs")
+        .where("state", JobState.Completed)
+        .orWhere("state", JobState.Failed)
+        .delete()
+    );
+  }
+
+  async upsertJobSchedule(
+    schedule: JobScheduleModel
+  ): Promise<JobScheduleModel> {
+    const model = SqliteJobScheduleModel.fromModel(schedule);
+    const toInsert = model.toRow();
+    await this.enqueue(() =>
+      this.connection("JobSchedules")
+        .insert(toInsert)
+        .onConflict(["key"])
+        .merge()
+    );
+    return model;
+  }
+
+  async fetchJobSchedule(key: string): Promise<JobScheduleModel | undefined> {
+    const row = await this.connection("JobSchedules").where({ key }).first();
+    return row && SqliteJobScheduleModel.fromRow(row);
+  }
+
+  async listReadyJobSchedules(limit: number): Promise<JobScheduleModel[]> {
+    const results = await this.connection("JobSchedules")
+      .leftJoin("Jobs", "JobSchedules.jobId", "Jobs.id")
+      .whereNull("Jobs.id")
+      .orWhereNot("Jobs.state", JobState.Pending)
+      .limit(limit);
+    return results.map((row) => SqliteJobScheduleModel.fromRow(row));
+  }
+}
+
+export class SqliteJobModel implements JobModel {
+  id!: string;
+  name!: string;
+  payload!: JobPayload;
+  result?: JobResult | undefined;
+  options?: JobOptions | undefined;
+  status?: JobStatus | undefined;
+  state!: JobState;
+
+  constructor(init?: JobModel) {
+    Object.assign(this, init);
+  }
+
+  toRow(): Record<string, string | number | undefined> {
+    const { id, name, payload, result, options = {}, status, state } = this;
+    const { priority } = options;
+    return {
+      id,
+      priority,
+      name,
+      state,
+      payload: JSON.stringify(payload),
+      options: JSON.stringify(options),
+      result: JSON.stringify(result),
+      status: JSON.stringify(status),
+    };
+  }
+
+  static fromModel(model: JobModel): SqliteJobModel {
+    return new SqliteJobModel(model);
+  }
+
+  static fromRow(
+    row: Record<string, string | number | undefined>
+  ): SqliteJobModel {
+    const { id, name, payload, result, options, status, state } = row;
+    if (!id || !name || !payload || !state) {
+      throw new Error("incomplete job from row");
+    }
+    return new SqliteJobModel({
+      id: id as string,
+      name: name as string,
+      state: state as JobState,
+      payload: payload && JSON.parse(payload as string),
+      result: result && JSON.parse(result as string),
+      options: options && JSON.parse(options as string),
+      status: status && JSON.parse(status as string),
+    });
+  }
+}
+
+export class SqliteJobScheduleModel extends BaseJobScheduleModel {
+  toRow(): Record<string, string | number | undefined> {
+    const { key, repeatOptions, jobTemplate, jobId, prevMillis, nextMillis } =
+      this;
+    return {
+      key,
+      repeatOptions: JSON.stringify(repeatOptions),
+      jobTemplate: JSON.stringify(jobTemplate),
+      jobId,
+      prevMillis,
+      nextMillis,
+    };
+  }
+
+  static fromModel(model: JobScheduleModel): SqliteJobScheduleModel {
+    return new SqliteJobScheduleModel(model);
+  }
+
+  static fromRow(
+    row: Record<string, string | number | undefined>
+  ): SqliteJobScheduleModel {
+    const { key, repeatOptions, jobTemplate, jobId, prevMillis, nextMillis } =
+      row;
+    if (
+      typeof key !== "string" ||
+      typeof repeatOptions !== "string" ||
+      typeof jobTemplate !== "string"
+    ) {
+      throw new Error("incomplete row");
+    }
+    return new SqliteJobScheduleModel({
+      key,
+      repeatOptions: JSON.parse(repeatOptions),
+      jobTemplate: JSON.parse(jobTemplate),
+      jobId: typeof jobId === "string" ? jobId : undefined,
+      prevMillis: typeof prevMillis === "number" ? prevMillis : undefined,
+      nextMillis: typeof nextMillis === "number" ? nextMillis : undefined,
+    });
+  }
+}

--- a/server/repositories/sqlite/jobs/migrations/20241104200400_initial.ts
+++ b/server/repositories/sqlite/jobs/migrations/20241104200400_initial.ts
@@ -1,0 +1,21 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema
+    .createTable("Jobs", (t) => {
+      t.increments("id").primary();
+      t.integer("priority").nullable();
+      t.string("reservation").nullable();
+      t.string("name");
+      t.string("state");
+      t.json("payload");
+      t.json("options").nullable();
+      t.json("result").nullable();
+      t.json("status").nullable();
+      t.timestamps(true, true, true);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTable("Jobs");
+}

--- a/server/repositories/sqlite/jobs/migrations/20241113171900_deduplication_id.ts
+++ b/server/repositories/sqlite/jobs/migrations/20241113171900_deduplication_id.ts
@@ -1,0 +1,22 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("Jobs", (t) => {
+    t.string("deduplicationId");
+  });
+
+  await knex.schema.alterTable("Jobs", (t) => {
+    t.unique(["deduplicationId"], {
+      indexName: "unique_deduplication_id_columns",
+    });
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("Jobs", (t) => {
+    t.dropUnique(["deduplicationId"], "unique_deduplication_id_columns");
+  });
+  await knex.schema.alterTable("Jobs", (t) => {
+    t.dropColumn("deduplicationId");
+  });
+}

--- a/server/repositories/sqlite/jobs/migrations/20241114143600_deferUntil.ts
+++ b/server/repositories/sqlite/jobs/migrations/20241114143600_deferUntil.ts
@@ -1,0 +1,13 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("Jobs", (t) => {
+    t.integer("deferUntil");
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable("Jobs", (t) => {
+    t.dropColumn("deferUntil");
+  });
+}

--- a/server/repositories/sqlite/jobs/migrations/20241119195000_scheduler.ts
+++ b/server/repositories/sqlite/jobs/migrations/20241119195000_scheduler.ts
@@ -1,0 +1,19 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema
+    .createTable("JobSchedules", (t) => {
+      t.increments("id").primary();
+      t.string("key").unique();
+      t.json("repeatOptions");
+      t.json("jobTemplate");
+      t.string("jobId").nullable();
+      t.integer("prevMillis").nullable();
+      t.integer("nextMillis").nullable();
+      t.timestamps(true, true, true);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTable("JobSchedules");
+}

--- a/server/services/feeds/jobs.ts
+++ b/server/services/feeds/jobs.ts
@@ -1,0 +1,47 @@
+import { Feed } from "./types";
+import { FeedsService } from ".";
+import { JobPayload, JobProgressFn } from "../jobs/types";
+import { FeedPollOptions } from "./poll";
+
+export const JOB_UPDATE_FEED = "updateFeed";
+
+export async function initJobs(this: FeedsService) {
+  const { jobs } = this.app;
+  if (!jobs) return;
+  await jobs.registerJobHandler(JOB_UPDATE_FEED, this.handleUpdateFeedJob);
+}
+
+export interface UpdateFeedJobPayload extends JobPayload {
+  feed: Feed;
+  options: FeedPollOptions;
+}
+
+export interface UpdateFeedJobResult {
+  feedId?: string;
+}
+
+export async function deferFeedUpdate(
+  this: FeedsService,
+  feed: Feed,
+  options: FeedPollOptions = {}
+) {
+  const { jobs } = this.app;
+  if (!jobs) return;
+  return jobs.add(
+    JOB_UPDATE_FEED,
+    { feed, options },
+    { deduplication: { id: `${JOB_UPDATE_FEED}:${feed.url}` } }
+  );
+}
+
+export async function handleUpdateFeedJob(
+  this: FeedsService,
+  payload: JobPayload,
+  progress: JobProgressFn
+): Promise<UpdateFeedJobResult> {
+  const { feed, options } = payload as UpdateFeedJobPayload;
+  const { forceFetch = false, maxage = this.app.config.get("feedPollMaxAge") } =
+    options;
+  const result = await this.update(feed, { forceFetch, maxage });
+  return { feedId: result?.feedId };
+}

--- a/server/services/fetch.ts
+++ b/server/services/fetch.ts
@@ -170,9 +170,11 @@ export class FetchService extends AppModule<IAppRequirements> {
         headersTimeout: timeout,
         bodyTimeout: timeout,
         signal: controller.signal,
+        /* TODO: debug why the event thrown by this is uncatchable?
         dispatcher: new Undici.Agent({
           maxResponseSize,
         }),
+        */
       });
       clearTimeout(abortTimeout);
       log.trace({

--- a/server/services/jobs/cli.ts
+++ b/server/services/jobs/cli.ts
@@ -1,0 +1,27 @@
+import { Command } from "commander";
+import { CliAppModule } from "../../app/modules";
+import { IJobsRepository, JobsService } from ".";
+
+export type IAppRequirements = {
+  jobs: JobsService;
+  jobsRepository: IJobsRepository;
+};
+
+export default class CliUnfurl extends CliAppModule<IAppRequirements> {
+  async initCli(program: Command) {
+    const { log } = this;
+    const { jobs, jobsRepository } = this.app;
+
+    const jobsProgram = program
+      .command("jobs")
+      .description("manage background jobs");
+
+    jobsProgram
+      .command("list")
+      .description("list jobs")
+      .action(async () => {
+        const jobs = await jobsRepository.listJobs();
+        log.info({ msg: "jobs", jobs });
+      });
+  }
+}

--- a/server/services/jobs/index.ts
+++ b/server/services/jobs/index.ts
@@ -1,0 +1,104 @@
+import { AppModule } from "../../app/modules";
+import { JobsServiceManager } from "./manager";
+import { JobsServiceQueue } from "./queue";
+import { JobsServiceScheduler } from "./scheduler";
+import { JobScheduleModel } from "./types";
+
+import { JobState, JobResult, JobModelNew, JobModel, JobStatus } from "./types";
+
+export * from "./types";
+export * from "./scheduler";
+
+export const configSchema = {
+  jobsQueueConcurrency: {
+    doc: "Number of jobs to run concurrently",
+    env: "JOBS_QUEUE_CONCURRENCY",
+    format: Number,
+    default: 4,
+  },
+  jobsPollIntervalPeriod: {
+    doc: "Interval in milliseconds to poll for new jobs",
+    env: "JOBS_POLL_INTERVAL_PERIOD",
+    format: Number,
+    default: 1000,
+  },
+  jobsSchedulerPollIntervalPeriod: {
+    doc: "Interval in milliseconds to poll for schedules",
+    env: "JOBS_SCHEDULER_POLL_INTERVAL_PERIOD",
+    format: Number,
+    default: 1000,
+  },
+  jobPurgeInterval: {
+    doc: "Interval in milliseconds to purge resolved jobs",
+    env: "JOBS_PURGE_INTERVAL",
+    format: Number,
+    default: 1000 * 60 * 60 * 24,
+  },
+};
+
+export interface IAppRequirements {
+  jobsRepository: IJobsRepository;
+}
+
+export class JobsService extends AppModule<IAppRequirements> {
+  // TODO: make these #private or use a WeakMap someday, to more explicitly
+  // define external JobsService interface?
+  manager: JobsServiceManager = new JobsServiceManager(this);
+  queue: JobsServiceQueue = new JobsServiceQueue(this);
+  scheduler: JobsServiceScheduler = new JobsServiceScheduler(this);
+
+  async init() {
+    await this.manager.init();
+    await this.queue.init();
+    await this.scheduler.init();
+    await super.init();
+  }
+
+  async deinit() {
+    await this.scheduler.deinit();
+    await this.queue.deinit();
+    await this.manager.deinit();
+    await super.deinit();
+  }
+
+  async start() {
+    await this.queue.start();
+  }
+
+  async pause() {
+    await this.queue.pause();
+  }
+
+  add = this.manager.add.bind(this.manager);
+  addBulk = this.manager.addBulk.bind(this.manager);
+  registerJobHandler = this.queue.registerJobHandler.bind(this.queue);
+  upsertJobSchedule = this.scheduler.upsertJobSchedule.bind(this.scheduler);
+  onIdle = this.queue.onIdle.bind(this.queue);
+}
+
+export interface IJobsRepository {
+  addJob(jobs: JobModelNew[]): Promise<string[]>;
+  listJobs(options?: {
+    name?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<JobModel[]>;
+  fetchJobById(id: string): Promise<JobModel | undefined>;
+  reserveJob(jobNames?: string[]): Promise<JobModel | undefined>;
+  retryJob(job: JobModel): Promise<void>;
+  updateJob<Result extends JobResult>({
+    id,
+    state,
+    status,
+    result,
+  }: {
+    id: string;
+    state?: JobState;
+    status?: JobStatus;
+    result?: Result;
+  }): Promise<void>;
+  purgeResolvedJobs(): Promise<void>;
+  upsertJobSchedule(schedule: JobScheduleModel): Promise<JobScheduleModel>;
+  fetchJobSchedule(key: string): Promise<JobScheduleModel | undefined>;
+  listReadyJobSchedules(limit: number): Promise<JobScheduleModel[]>;
+}

--- a/server/services/jobs/manager.test.ts
+++ b/server/services/jobs/manager.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { JobModel, JobState } from "./types";
+import assert from "node:assert";
+import { createTestJobs, TestApp } from "./test-utils";
+
+describe("services/jobs", () => {
+  let app: TestApp;
+
+  beforeEach(async () => {
+    app = new TestApp();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.deinit();
+  });
+
+  describe("JobsServiceManager", () => {
+    describe("add", () => {
+      it("should add jobs", async () => {
+        const { jobs } = app;
+
+        const testJobs = createTestJobs(10);
+        const jobIds = await jobs.addBulk(testJobs);
+
+        const fetchedJobs = await app.jobsRepository.listJobs();
+        const fetchedJobIds = fetchedJobs.map((job) => job.id);
+
+        assert.deepStrictEqual(jobIds, fetchedJobIds);
+      });
+    });
+
+    describe("reserve", async () => {
+      it("should reserve jobs in order of priority", async () => {
+        const { jobs } = app;
+
+        const testJobs = createTestJobs(10);
+        const jobIds = await jobs.addBulk(testJobs);
+
+        const reservations = [];
+
+        for (let i = 0; i < testJobs.length; i++) {
+          reservations.push(async () => {
+            const reservedJob = await jobs.manager.reserveJob();
+            assert(reservedJob);
+            assert.equal(reservedJob.id, jobIds[i]);
+            assert.equal(reservedJob.state, JobState.Reserved);
+          });
+        }
+
+        // Fire off all the reservation attempts in parallel,
+        // the underlying repository should serialize them
+        await Promise.all(reservations.map((r) => r()));
+      });
+
+      it("should support reserving by job name", async () => {
+        const { jobs } = app;
+
+        const testJobs = createTestJobs(10);
+        const jobIds = await jobs.addBulk(testJobs);
+
+        const name = testJobs[5].name;
+        const reservedJob = await jobs.manager.reserveJob([name]);
+
+        assert(reservedJob);
+        assert.equal(reservedJob.id, jobIds[5]);
+      });
+
+      it("should support reserving by multiple job names", async () => {
+        const { jobs } = app;
+
+        const startIdx = 3;
+        const endIdx = 7;
+
+        const testJobs = createTestJobs(10);
+        const jobIds = await jobs.addBulk(testJobs);
+        const expectedJobIds = jobIds.slice(startIdx, endIdx);
+        const names = testJobs.slice(startIdx, endIdx).map((job) => job.name);
+
+        const reservedJobs = [];
+        for (let idx = 0; idx < names.length; idx++) {
+          const reservedJob = await jobs.manager.reserveJob(names);
+          assert(reservedJob);
+          reservedJobs.push(reservedJob);
+        }
+
+        const reservedJobIds = reservedJobs.map((job) => job.id);
+        assert.deepEqual(reservedJobIds, expectedJobIds);
+      });
+
+      it("should not reserve completed or failed jobs", async () => {
+        const { jobs } = app;
+
+        const testJobs = createTestJobs(10);
+        const jobIds = await jobs.addBulk(testJobs);
+
+        const [completedId, failedId, ...pendingIds] = jobIds;
+
+        await jobs.manager.moveJobToCompleted(completedId, { foo: "bar" });
+        await jobs.manager.moveJobToFailed(failedId, { baz: "quux" });
+
+        const reservedJobs = [];
+        let job: JobModel | undefined;
+        while ((job = await jobs.manager.reserveJob())) {
+          reservedJobs.push(job);
+        }
+
+        assert.equal(reservedJobs.length, pendingIds.length);
+      });
+    });
+
+    describe("purgeResolvedJobs", () => {
+      it("should remove completed and failed jobs", async () => {
+        const { jobs } = app;
+
+        const testJobs = createTestJobs(10);
+        const jobIds = await jobs.addBulk(testJobs);
+
+        const [completedId, failedId, ...pendingIds] = jobIds;
+
+        await jobs.manager.moveJobToCompleted(completedId, { foo: "bar" });
+        await jobs.manager.moveJobToFailed(failedId, { foo: "bar" });
+        await jobs.manager.purgeResolvedJobs();
+
+        const fetchedJobs = await app.jobsRepository.listJobs();
+        const fetchedJobIds = fetchedJobs.map((job) => job.id);
+
+        assert.deepEqual(fetchedJobIds, pendingIds);
+      });
+    });
+
+    describe("JobModel.options", () => {
+      it("should support a deduplication ID to prevent inserting duplicate jobs", async () => {
+        const { jobs } = app;
+
+        const [testJob1, testJob2] = createTestJobs(2);
+        const deduplicationId1 = "dedupe-me-1";
+        const deduplicationId2 = "dedupe-me-2";
+
+        const jobId1 = await jobs.add(testJob1.name, testJob1.payload, {
+          deduplication: { id: deduplicationId1 },
+        });
+
+        for (let i = 0; i < 5; i++) {
+          const duplicateJobId1 = await jobs.add(
+            testJob1.name,
+            testJob1.payload,
+            {
+              deduplication: { id: deduplicationId1 },
+            }
+          );
+          assert.equal(jobId1, duplicateJobId1);
+        }
+
+        const jobId2 = await jobs.add(testJob2.name, testJob2.payload, {
+          deduplication: { id: deduplicationId2 },
+        });
+        assert.notEqual(jobId1, jobId2);
+
+        for (let i = 0; i < 5; i++) {
+          const duplicateJobId2 = await jobs.add(
+            testJob2.name,
+            testJob2.payload,
+            {
+              deduplication: { id: deduplicationId2 },
+            }
+          );
+          assert.equal(jobId2, duplicateJobId2);
+        }
+
+        await jobs.manager.reserveJob([testJob1.name]);
+        await jobs.manager.reserveJob([testJob2.name]);
+
+        const newJobId1 = await jobs.add(testJob1.name, testJob1.payload, {
+          deduplication: { id: deduplicationId1 },
+        });
+        assert.notEqual(jobId1, newJobId1);
+
+        const newJobId2 = await jobs.add(testJob2.name, testJob2.payload, {
+          deduplication: { id: deduplicationId2 },
+        });
+        assert.notEqual(jobId2, newJobId2);
+      });
+    });
+  });
+});

--- a/server/services/jobs/manager.ts
+++ b/server/services/jobs/manager.ts
@@ -1,0 +1,104 @@
+import { JobsService } from ".";
+import { JobResult, JobModelNew, JobState, JobModel, JobStatus } from "./types";
+
+export class JobsServiceManager {
+  parent: JobsService;
+
+  constructor(parent: JobsService) {
+    this.parent = parent;
+  }
+
+  async init() {}
+
+  async deinit() {}
+
+  async add(
+    name: JobModelNew["name"],
+    payload: JobModelNew["payload"],
+    options?: JobModelNew["options"]
+  ) {
+    const ids = await this.addBulk([{ name, payload, options }]);
+    return ids[0];
+  }
+
+  async addBulk(jobs: JobModelNew[]) {
+    const jobIds = await this.parent.app.jobsRepository.addJob(jobs);
+    await this.parent.queue.maybeFillQueue();
+    return jobIds;
+  }
+
+  async reserveJob(jobNames?: string[]) {
+    return this.parent.app.jobsRepository.reserveJob(jobNames);
+  }
+
+  async pendingCount() {
+    // TODO: this is butts, build a proper repository query for this
+    return this.parent.app.jobsRepository
+      .listJobs()
+      .then(
+        (jobs) => jobs.filter((job) => job.state === JobState.Pending).length
+      );
+  }
+
+  async listJobs(options?: { name?: string; limit?: number; offset?: number }) {
+    return this.parent.app.jobsRepository.listJobs(options);
+  }
+
+  async fetchJob(id: string) {
+    return this.parent.app.jobsRepository.fetchJobById(id);
+  }
+
+  async moveJobToStarted(id: string) {
+    await this.parent.app.jobsRepository.updateJob({
+      id,
+      state: JobState.Started,
+    });
+  }
+
+  async updateJobProgress(
+    id: string,
+    progress: number,
+    statusMessage?: string
+  ) {
+    await this.parent.app.jobsRepository.updateJob({
+      id,
+      state: JobState.Started,
+      status: {
+        progress,
+        statusMessage,
+      },
+    });
+  }
+
+  async moveJobToCompleted<Result extends JobResult>(
+    id: string,
+    result?: Result
+  ) {
+    await this.parent.app.jobsRepository.updateJob({
+      id,
+      state: JobState.Completed,
+      result,
+    });
+  }
+
+  async moveJobToFailed<Result extends JobResult>(id: string, result?: Result) {
+    await this.parent.app.jobsRepository.updateJob({
+      id,
+      state: JobState.Failed,
+      result,
+    });
+  }
+
+  async retryJob(job: JobModel) {
+    await this.parent.app.jobsRepository.retryJob(job);
+    await this.parent.queue.maybeFillQueue();
+  }
+
+  async updateJobState(id: string, state: JobState, status?: JobStatus) {
+    await this.parent.app.jobsRepository.updateJob({ id, state, status });
+  }
+
+  async purgeResolvedJobs() {
+    await this.parent.app.jobsRepository.purgeResolvedJobs();
+  }
+}

--- a/server/services/jobs/queue.test.ts
+++ b/server/services/jobs/queue.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import { JobHandler, JobState } from "./types";
+import assert from "node:assert";
+import { createTestJobs, TestApp } from "./test-utils";
+
+describe("services/jobs", () => {
+  let app: TestApp;
+  let oldPollInterval: number;
+
+  beforeEach(async () => {
+    app = new TestApp();
+    oldPollInterval = app.config.get("jobsPollIntervalPeriod");
+    app.config.set("jobsPollIntervalPeriod", 100);
+    app.jobs.pause();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    app.config.set("jobsPollIntervalPeriod", oldPollInterval);
+    await app.deinit();
+  });
+
+  describe("JobsServiceQueue", () => {
+    describe("startQueue", () => {
+      it("should start running queued jobs", async () => {
+        const { jobs } = app;
+        jobs.start();
+
+        const add = mock.fn<JobHandler>(async (payload) => {
+          const { a, b } = payload as { a: number; b: number };
+          return { sum: a + b };
+        });
+        jobs.registerJobHandler("add", add);
+
+        const numberOfJobs = 10;
+        const testJobs = Array.from({ length: numberOfJobs }, (_, i) => ({
+          name: `add`,
+          payload: { a: i, b: i + 1 },
+        }));
+        await jobs.addBulk(testJobs);
+
+        await jobs.onIdle();
+        await jobs.pause();
+
+        const fetchedJobs = await app.jobsRepository.listJobs();
+        const completedJobs = fetchedJobs.filter(
+          (job) => job.state === JobState.Completed
+        );
+        assert.equal(completedJobs.length, numberOfJobs);
+
+        assert.equal(add.mock.callCount(), numberOfJobs);
+        for (const job of completedJobs) {
+          assert.deepEqual(
+            job.result,
+            await add(job.payload as any, async () => {})
+          );
+        }
+      });
+    });
+
+    describe("update", () => {
+      it("should update job state and status when passed to a job handler", async () => {
+        const { jobs } = app;
+        jobs.start();
+
+        const testJob = {
+          name: "test",
+          payload: { foo: "bar" },
+        };
+
+        const handler: JobHandler = async (payload, progress) => {
+          assert.deepEqual(payload, testJob.payload);
+          await progress(0.5, "halfway there");
+          return { success: true };
+        };
+
+        jobs.registerJobHandler(testJob.name, handler);
+        const jobId = await jobs.add(testJob.name, testJob.payload);
+
+        await jobs.onIdle();
+        await jobs.pause();
+
+        const fetchedJob = await app.jobsRepository.fetchJobById(jobId);
+        assert.equal(fetchedJob?.state, JobState.Completed);
+        assert.equal(fetchedJob?.status?.progress, 0.5);
+        assert.equal(fetchedJob?.status?.statusMessage, "halfway there");
+      });
+    });
+
+    describe("registerHandler", () => {
+      it("should support many named job handlers", async () => {
+        const { jobs } = app;
+        jobs.start();
+
+        const numberOfJobs = 10;
+        const testJobs = createTestJobs(numberOfJobs);
+
+        // Register a unique handler for every named job using mocks
+        const jobMocks = testJobs.map((job) => {
+          const handlerMock = mock.fn(async (payload) => ({ success: true }));
+          jobs.registerJobHandler(job.name, handlerMock);
+          return handlerMock;
+        });
+
+        await jobs.addBulk(testJobs);
+        await jobs.onIdle();
+        await jobs.pause();
+
+        const fetchedJobs = await app.jobsRepository.listJobs();
+        const completedJobs = fetchedJobs.filter(
+          (job) => job.state === JobState.Completed
+        );
+        assert(completedJobs.length === numberOfJobs);
+
+        // Verify that each handler was called exactly once
+        jobMocks.forEach((handlerMock) => {
+          assert.equal(handlerMock.mock.callCount(), 1);
+        });
+      });
+    });
+
+    describe("JobModel.options", () => {
+      it("should support an attempt options to specify number of retries", async (t) => {
+        const { jobs } = app;
+
+        const maxAttempts = 5;
+
+        const testJob = {
+          ...createTestJobs(1)[0],
+          options: { attempts: maxAttempts },
+        };
+
+        let attempt = 0;
+        const handler = mock.fn<JobHandler>(async (payload) => {
+          if (attempt++ < maxAttempts - 1) throw new Error("failed");
+          return { success: true };
+        });
+        jobs.registerJobHandler(testJob.name, handler);
+
+        await jobs.add(testJob.name, testJob.payload, {
+          attempts: maxAttempts,
+        });
+
+        await jobs.start();
+        await jobs.onIdle();
+        await jobs.pause();
+
+        const fetchedJobs = await app.jobsRepository.listJobs();
+        const completedJobs = fetchedJobs.filter(
+          (job) => job.state === JobState.Completed
+        );
+        assert.equal(completedJobs.length, 1);
+        assert.equal(handler.mock.callCount(), maxAttempts);
+      });
+
+      it("should support deferUntil option to delay job until time", async () => {
+        const delay = app.config.get("jobsPollIntervalPeriod") * 1.5;
+        const deferUntil = Date.now() + delay;
+        await testDelayedJobExecution("deferUntil", deferUntil);
+      });
+
+      it("should support delay option to delay job execution for a period", async () => {
+        const delay = app.config.get("jobsPollIntervalPeriod") * 1.5;
+        await testDelayedJobExecution("delay", delay);
+      });
+
+      async function testDelayedJobExecution(
+        delayOption: "deferUntil" | "delay",
+        delayValue: number
+      ) {
+        const { jobs } = app;
+
+        const testJob = createTestJobs(1)[0];
+
+        const handler = mock.fn<JobHandler>(async (payload) => ({
+          success: true,
+        }));
+        jobs.registerJobHandler(testJob.name, handler);
+
+        await jobs.add(testJob.name, testJob.payload, {
+          [delayOption]: delayValue,
+        });
+
+        await jobs.start();
+        await jobs.onIdle();
+
+        const fetchedJobs = await app.jobsRepository.listJobs();
+        const completedJobs = fetchedJobs.filter(
+          (job) => job.state === JobState.Completed
+        );
+        assert.equal(completedJobs.length, 0);
+
+        await new Promise((resolve) =>
+          setTimeout(resolve, app.config.get("jobsPollIntervalPeriod") * 3)
+        );
+
+        await jobs.onIdle();
+        await jobs.pause();
+
+        const fetchedJobsAfterDelay = await app.jobsRepository.listJobs();
+        const completedJobsAfterDelay = fetchedJobsAfterDelay.filter(
+          (job) => job.state === JobState.Completed
+        );
+        assert.equal(completedJobsAfterDelay.length, 1);
+        assert.equal(handler.mock.callCount(), 1);
+      }
+    });
+  });
+});

--- a/server/services/jobs/queue.ts
+++ b/server/services/jobs/queue.ts
@@ -1,0 +1,92 @@
+import PQueue from "p-queue";
+import { JobsService } from ".";
+import { JobPayload, JobResult, JobHandler, JobModel } from "./types";
+
+export class JobsServiceQueue {
+  parent: JobsService;
+  queue = new PQueue({ concurrency: 1, autoStart: false });
+  handlers = new Map<string, JobHandler>();
+  jobsPollIntervalTimer: NodeJS.Timeout | null = null;
+
+  constructor(parent: JobsService) {
+    this.parent = parent;
+  }
+
+  async init() {
+    const { config } = this.parent.app;
+    this.queue.concurrency = config.get("jobsQueueConcurrency");
+  }
+
+  async deinit() {
+    await this.pause();
+  }
+
+  async start() {
+    const { config } = this.parent.app;
+    this.queue.start();
+
+    if (this.jobsPollIntervalTimer)
+      clearInterval(this.jobsPollIntervalTimer);
+    this.jobsPollIntervalTimer = setInterval(
+      () => this.maybeFillQueue(),
+      config.get("jobsPollIntervalPeriod")
+    );
+
+    await this.maybeFillQueue();
+  }
+
+  async pause() {
+    this.queue.pause();
+    if (this.jobsPollIntervalTimer) clearInterval(this.jobsPollIntervalTimer);
+  }
+
+  async onIdle() {
+    return this.queue.onIdle();
+  }
+
+  async maybeFillQueue() {
+    const { manager } = this.parent;
+    if (this.queue.isPaused) return;
+
+    while (this.queue.size < this.queue.concurrency) {
+      const job = await manager.reserveJob();
+      if (!job) break;
+      this.queue.add(() => this.runJob(job));
+    }
+  }
+
+  async registerJobHandler(name: string, worker: JobHandler) {
+    this.handlers.set(name, worker);
+  }
+
+  async runJob(job: JobModel) {
+    const { log, manager } = this.parent;
+    const { id, name, payload } = job;
+    log.trace({ msg: "Running job", id, name });
+
+    const handler = this.handlers.get(name);
+    if (!handler) {
+      manager.moveJobToFailed(id, { error: "No handler registered for job" });
+      return;
+    }
+
+    try {
+      await manager.moveJobToStarted(id);
+      const result = await handler(payload, (progress, statusMessage) =>
+        manager.updateJobProgress(id, progress, statusMessage)
+      );
+      await manager.moveJobToCompleted(id, result);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "An error occurred";
+
+      if (job.options?.attempts && job.options.attempts > 1) {
+        await manager.retryJob(job);
+      } else {
+        await manager.moveJobToFailed(id, { error, errorMessage: message });
+      }
+    }
+
+    await this.maybeFillQueue();
+  }
+}

--- a/server/services/jobs/scheduler.test.ts
+++ b/server/services/jobs/scheduler.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import { BaseApp } from "../../app";
+import { IApp } from "../../app/types";
+import { rimraf } from "rimraf";
+import { BaseJobScheduleModel, JobsService, JobState } from ".";
+import SqliteJobsRepository from "../../repositories/sqlite/jobs";
+import assert from "node:assert";
+
+describe("services/jobs", () => {
+  let app: TestApp;
+  let oldPollInterval: number;
+
+  beforeEach(async () => {
+    app = new TestApp();
+    oldPollInterval = app.config.get("jobsPollIntervalPeriod");
+    app.config.set("jobsPollIntervalPeriod", 100);
+    app.jobs.pause();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    app.config.set("jobsPollIntervalPeriod", oldPollInterval);
+    await app.deinit();
+  });
+
+  describe("JobsServiceScheduler", () => {
+    describe("upsertJobSchedule", () => {
+      it("should upsert a job schedule with nextMillis calculated", async () => {
+        const key = "test-schedule-every";
+        const now = Date.now();
+        const every = 10000;
+        const expectedNextMillis = now + every;
+
+        const schedule = await app.jobs.upsertJobSchedule(
+          key,
+          { every },
+          { name: "test-1", payload: { foo: "bar" } }
+        );
+        assert(schedule.nextMillis);
+        assert.equal(
+          Math.floor(schedule.nextMillis / 10),
+          Math.floor(expectedNextMillis / 10)
+        );
+
+        const storedSchedule = await app.jobs.scheduler.fetchJobSchedule(key);
+        assert(storedSchedule);
+        assert(storedSchedule.nextMillis);
+        assert.equal(
+          Math.floor(storedSchedule.nextMillis / 10),
+          Math.floor(expectedNextMillis / 10)
+        );
+      });
+    });
+
+    describe("listReadyJobSchedules", () => {
+      it("should only list schedules for which there are no pending jobs", async () => {
+        const key = "test-schedule-1";
+        const every = 10000;
+
+        const schedule = await app.jobs.upsertJobSchedule(
+          key,
+          { every },
+          { name: "test-1", payload: { foo: "bar" } }
+        );
+
+        const schedules = await app.jobs.scheduler.listReadyJobSchedules();
+        assert.equal(schedules.length, 1);
+        assert.equal(schedules[0].key, key);
+
+        // now add a job for this schedule
+        const jobId = await app.jobs.manager.add("test-1", { foo: "bar" });
+
+        // set the schedule's jobId to the id of the job just created
+        schedule.jobId = jobId;
+        await app.jobs.scheduler.saveJobSchedule(schedule);
+
+        const schedules2 = await app.jobs.scheduler.listReadyJobSchedules();
+        assert.equal(schedules2.length, 0);
+
+        // now mark the job as complete
+        const jobs = await app.jobs.manager.listJobs();
+        await app.jobs.manager.updateJobState(jobs[0].id, JobState.Completed);
+
+        const schedules3 = await app.jobs.scheduler.listReadyJobSchedules();
+        assert.equal(schedules3.length, 1);
+      });
+    });
+
+    describe("checkSchedules", () => {
+      it("should add a job for a schedule that is ready", async () => {
+        const now = Date.now();
+        const every = 10000;
+
+        // Create one schedule that is ready
+        const key = "test-schedule-1";
+        const schedule = await app.jobs.upsertJobSchedule(
+          key,
+          { every },
+          { name: "test-1", payload: { foo: "bar" } }
+        );
+        schedule.nextMillis = now - 5000;
+        await app.jobs.scheduler.saveJobSchedule(schedule);
+
+        // Create another schedule
+        const key2 = "test-schedule-2";
+        const schedule2 = await app.jobs.upsertJobSchedule(
+          key2,
+          { every },
+          { name: "test-2", payload: { foo: "bar" } }
+        );
+        schedule2.nextMillis = now - 5000;
+        await app.jobs.scheduler.saveJobSchedule(schedule2);
+
+        // Add a job for the second schedule, so it's not ready
+        const jobId = await app.jobs.manager.add("test-2", { foo: "bar" });
+        schedule2.jobId = jobId;
+        await app.jobs.scheduler.saveJobSchedule(schedule2);
+
+        // Only one job should exist, so far
+        const jobs = await app.jobs.manager.listJobs();
+        assert.equal(jobs.length, 1);
+        assert.equal(jobs[0].name, "test-2");
+
+        // Check schedules and add jobs
+        await app.jobs.scheduler.checkSchedules();
+
+        // Now two jobs should exist
+        const jobs2 = await app.jobs.manager.listJobs();
+        assert.equal(jobs2.length, 2);
+        assert.equal(jobs2[0].name, "test-2");
+        assert.equal(jobs2[1].name, "test-1");
+      });
+    });
+  });
+
+  describe("BaseJobScheduleModel", () => {
+    describe("calculateNextExecutionTime", () => {
+      it("should calculate the next execution time based on `every` option", () => {
+        const prevMillis = Date.now();
+        const every = 10000;
+
+        const schedule = BaseJobScheduleModel.create(
+          "test-schedule-every",
+          { every },
+          { name: "test-1", payload: { foo: "bar" } }
+        );
+
+        const nextMillis = schedule.calculateNextExecutionTime(prevMillis);
+        assert.equal(nextMillis, prevMillis + every);
+      });
+
+      it("should ensure with `every` option that the job is scheduled in the future", () => {
+        const pastFactor = 3.5;
+        const every = 1000;
+        const now = Date.now();
+        const schedule = BaseJobScheduleModel.create(
+          "test-schedule-every",
+          { every },
+          { name: "test-1", payload: { foo: "bar" } }
+        );
+        schedule.prevMillis = now - every * (pastFactor + 1);
+        schedule.nextMillis = now - every * pastFactor;
+
+        schedule.advanceNextMillis();
+
+        assert(schedule.nextMillis > now);
+      });
+
+      it("should calculate the next execution time based on `pattern` option", () => {
+        // Every half-hour should mean that even counting from 12 minutes after
+        // the hour yields 30 min after the hour
+        const pattern = "* 30 * * * *";
+        const prevDate = "2024-11-17T12:12:00.000Z";
+        const expectedNextDate = "2024-11-17T12:30:00.000Z";
+
+        const schedule = BaseJobScheduleModel.create(
+          "test-schedule-pattern",
+          { pattern },
+          { name: "test-1", payload: { foo: "bar" } }
+        );
+
+        const prevMillis = new Date(prevDate).getTime();
+        const nextMillis = schedule.calculateNextExecutionTime(prevMillis);
+        assert.equal(new Date(nextMillis).toISOString(), expectedNextDate);
+      });
+
+      it("should ensure with `pattern` option that the job is scheduled in the future", () => {
+        const pattern = "*/5 * * * * *";
+        const now = 1732481921066;
+
+        const schedule = BaseJobScheduleModel.create(
+          "test-schedule-pattern",
+          { pattern },
+          { name: "test-1", payload: { foo: "bar" } }
+        );
+        schedule.prevMillis = now - 1000 * 11;
+        schedule.nextMillis = now - 1000 * 6;
+
+        schedule.advanceNextMillis();
+
+        assert(schedule.nextMillis > now);
+      });
+    });
+  });
+});
+
+export class TestApp extends BaseApp implements IApp {
+  jobsRepository = new SqliteJobsRepository(this);
+  jobs = new JobsService(this);
+
+  constructor(
+    testDatabasePath = `data/test/jobs/${Date.now()}-${Math.random()}`
+  ) {
+    super();
+    const app = this;
+    this.modules.push(this.jobsRepository, this.jobs);
+    this.config.set("sqliteDatabasePath", testDatabasePath);
+  }
+
+  async init() {
+    await rimraf(this.config.get("sqliteDatabasePath"));
+    return super.init();
+  }
+
+  async deinit() {
+    await rimraf(this.config.get("sqliteDatabasePath"));
+    return super.deinit();
+  }
+}

--- a/server/services/jobs/scheduler.ts
+++ b/server/services/jobs/scheduler.ts
@@ -1,0 +1,142 @@
+import { JobsService } from ".";
+import { JobModelNew, JobRepeatOptions, JobScheduleModel } from "./types";
+import CronParser from "cron-parser";
+
+export const JOB_PURGE_RESOLVED_JOBS = "purgeResolvedJobs";
+
+export class JobsServiceScheduler {
+  parent: JobsService;
+  schedulerPollIntervalTimer: NodeJS.Timeout | null = null;
+
+  constructor(parent: JobsService) {
+    this.parent = parent;
+  }
+
+  async init() {}
+
+  async deinit() {
+    await this.pause();
+  }
+
+  async start() {
+    const { config } = this.parent.app;
+
+    if (this.schedulerPollIntervalTimer)
+      clearInterval(this.schedulerPollIntervalTimer);
+    this.schedulerPollIntervalTimer = setInterval(
+      () => this.checkSchedules(),
+      config.get("jobsSchedulerPollIntervalPeriod")
+    );
+  }
+
+  async pause() {
+    if (this.schedulerPollIntervalTimer)
+      clearInterval(this.schedulerPollIntervalTimer);
+  }
+
+  async setupJobPurge() {
+    await this.parent.registerJobHandler(JOB_PURGE_RESOLVED_JOBS, async () => {
+      await this.parent.manager.purgeResolvedJobs();
+      return { success: true };
+    });
+    await this.upsertJobSchedule(
+      `schedule-periodic-${JOB_PURGE_RESOLVED_JOBS}`,
+      { every: this.parent.app.config.get("jobPurgeInterval") },
+      { name: JOB_PURGE_RESOLVED_JOBS, payload: {} }
+    );
+  }
+
+  async checkSchedules() {
+    const schedules = await this.listReadyJobSchedules();
+
+    for (const schedule of schedules as BaseJobScheduleModel[]) {
+      // Advance the schedule to the next future execution time
+      schedule.advanceNextMillis();
+
+      // Create a new job for this schedule and defer it until the next execution time
+      const jobId = await this.parent.manager.add(
+        schedule.jobTemplate.name,
+        schedule.jobTemplate.payload,
+        {
+          ...schedule.jobTemplate.options,
+          deferUntil: schedule.nextMillis,
+        }
+      );
+
+      // Update the schedule with the new job ID
+      if (jobId) {
+        schedule.jobId = jobId;
+        await this.saveJobSchedule(schedule);
+      }
+    }
+  }
+
+  async upsertJobSchedule(
+    key: string,
+    repeatOptions: JobRepeatOptions,
+    jobTemplate: JobModelNew
+  ) {
+    const jobSchedule = BaseJobScheduleModel.create(
+      key,
+      repeatOptions,
+      jobTemplate
+    );
+    jobSchedule.advanceNextMillis();
+    return this.parent.app.jobsRepository.upsertJobSchedule(jobSchedule);
+  }
+
+  async saveJobSchedule(jobSchedule: JobScheduleModel) {
+    // TODO: move this to a job model method?
+    return this.parent.app.jobsRepository.upsertJobSchedule(jobSchedule);
+  }
+
+  async fetchJobSchedule(key: string) {
+    return this.parent.app.jobsRepository.fetchJobSchedule(key);
+  }
+
+  async listReadyJobSchedules(limit: number = 10) {
+    return this.parent.app.jobsRepository.listReadyJobSchedules(limit);
+  }
+}
+
+export class BaseJobScheduleModel implements JobScheduleModel {
+  key!: string;
+  repeatOptions!: JobRepeatOptions;
+  jobTemplate!: JobModelNew;
+
+  jobId?: string | undefined;
+  count?: number | undefined;
+  prevMillis?: number | undefined;
+  nextMillis?: number | undefined;
+
+  constructor(init: JobScheduleModel) {
+    Object.assign(this, init);
+  }
+
+  static create(
+    key: string,
+    repeatOptions: JobRepeatOptions,
+    jobTemplate: JobModelNew
+  ) {
+    return new BaseJobScheduleModel({ key, repeatOptions, jobTemplate });
+  }
+
+  advanceNextMillis(now: number = Date.now()) {
+    // TODO: need a panic count after which to break infinite loop and schedule arbitrarily into the future?
+    while (!this.nextMillis || this.nextMillis < now) {
+      this.prevMillis = this.nextMillis || now;
+      this.nextMillis = this.calculateNextExecutionTime(this.prevMillis);
+    }
+  }
+
+  calculateNextExecutionTime(prevMillis: number) {
+    if ("every" in this.repeatOptions) {
+      return prevMillis + this.repeatOptions.every;
+    }
+    const interval = CronParser.parseExpression(this.repeatOptions.pattern, {
+      currentDate: new Date(prevMillis),
+    });
+    const next = interval.next();
+    return next.getTime();
+  }
+}

--- a/server/services/jobs/test-utils.ts
+++ b/server/services/jobs/test-utils.ts
@@ -1,0 +1,38 @@
+import { BaseApp } from "@/app";
+import { IApp } from "@/app/types";
+import SqliteJobsRepository from "@/repositories/sqlite/jobs";
+import { rimraf } from "rimraf";
+import { JobsService } from ".";
+import { JobModelNew } from "./types";
+
+export function createTestJobs(amount: number = 10): JobModelNew[] {
+  return Array.from({ length: amount }, (_, i) => ({
+    name: `test-job-${i}`,
+    payload: { i, foo: "bar" },
+    options: { priority: i },
+  }));
+}
+
+export class TestApp extends BaseApp implements IApp {
+  jobsRepository = new SqliteJobsRepository(this);
+  jobs = new JobsService(this);
+
+  constructor(
+    testDatabasePath = `data/test/jobs/${Date.now()}-${Math.random()}`
+  ) {
+    super();
+    const app = this;
+    this.modules.push(this.jobsRepository, this.jobs);
+    this.config.set("sqliteDatabasePath", testDatabasePath);
+  }
+
+  async init() {
+    await rimraf(this.config.get("sqliteDatabasePath"));
+    return super.init();
+  }
+
+  async deinit() {
+    await rimraf(this.config.get("sqliteDatabasePath"));
+    return super.deinit();
+  }
+}

--- a/server/services/jobs/types.ts
+++ b/server/services/jobs/types.ts
@@ -1,0 +1,76 @@
+export interface JobModel {
+  id: string;
+  name: string;
+  payload: JobPayload;
+  options?: JobOptions;
+  state: JobState;
+  status?: JobStatus;
+  result?: JobResult;
+}
+
+export type JobModelNew = Pick<JobModel, "name" | "payload" | "options">;
+
+export interface JobOptions {
+  priority?: number;
+  attempts?: number;
+  deduplication?: {
+    id: string;
+  };
+  deferUntil?: number;
+  delay?: number;
+}
+
+export enum JobState {
+  Pending = "Pending",
+  Reserved = "Reserved",
+  Started = "Started",
+  Completed = "Completed",
+  Failed = "Failed",
+}
+
+export interface JobLogEntry {
+  timestamp: Date;
+  level: number;
+  message: string;
+  data?: Record<string, string>;
+}
+
+export interface JobStatus {
+  progress?: number;
+  statusMessage?: string;
+  startTime?: Date;
+  endTimeEstimated?: Date;
+  endTime?: Date;
+  log?: JobLogEntry[];
+}
+
+export interface JobPayload extends Record<string, any> {
+  [key: string]: any;
+}
+
+export interface JobResult extends Record<string, any> {
+  [key: string]: any;
+}
+
+export type JobProgressFn = (
+  progress: number,
+  statusMessage?: string
+) => Promise<void>;
+
+export type JobHandler = (
+  payload: JobPayload,
+  update: JobProgressFn
+) => Promise<JobResult>;
+
+export interface JobScheduleModel {
+  key: string;
+  repeatOptions: JobRepeatOptions;
+  jobTemplate: JobModelNew;
+
+  count?: number;
+  jobId?: string;
+  prevMillis?: number;
+  nextMillis?: number;
+}
+
+export type JobRepeatOptions = { pattern: string } | { every: number };

--- a/server/web/index.ts
+++ b/server/web/index.ts
@@ -18,8 +18,6 @@ import FastifyRequestContextPlugin from "@fastify/request-context";
 
 import AjvErrors from "ajv-errors";
 
-import { IApp, ICliApp } from "../app/types";
-
 import { HomeRouter } from "./home";
 import { ProfilesRouter } from "./profiles";
 import { BookmarksRouter } from "./bookmarks";
@@ -38,10 +36,10 @@ import { Boom } from "@hapi/boom";
 
 import templateError from "./templates/errors/error";
 import templateNotFound from "./templates/errors/notFound";
-import templateForbidden from "./templates/errors/forbidden";
 import { FeedsService } from "../services/feeds";
 import { Command } from "commander";
 import { UnfurlService } from "../services/unfurl";
+import { JobsService } from "../services/jobs";
 
 export const configSchema = {
   host: {
@@ -112,6 +110,7 @@ export type IAppRequirements = {
   profiles: ProfileService;
   bookmarks: BookmarksService;
   unfurl: UnfurlService;
+  jobs?: JobsService;
 };
 
 export default class Server extends CliAppModule<IAppRequirements> {
@@ -123,8 +122,7 @@ export default class Server extends CliAppModule<IAppRequirements> {
   }
 
   async commandServe() {
-    const { log } = this;
-    const { config } = this.app;
+    const { config, jobs } = this.app;
 
     this.setDefaultSiteUrl();
 


### PR DESCRIPTION
Job queue shenanigans in progress.

Trying to follow some of the same patterns [as BullMQ](https://docs.bullmq.io/guide/introduction) with an eye toward that queue as a hosting upgrade path.

TODO:

- [x] use "returning" clause in reservation update rather than update-then-select?
- [x] deduplicate jobs
- [x] (punted to #210) named queues as separate from named jobs - e.g. to group jobs with shared concurrency / priority limits
- [x] remove the types for JobPayload and JobResult? Doesn't seem to actually be paying off for typed jobs
- [x] do we even really need JobResult right now? maybe jobs should be fire-and-forget and return void
- [x] (#213) build cli command to get basic queue stats - e.g. pending job counts
- [x] retry jobs
- [x] (#212) handle stalled, crashed, interrupted, timed out jobs
- [x] delayed jobs - deferUntil
- [x] scheduled jobs? - e.g. generate jobs periodically ala [bull job schedulers](https://docs.bullmq.io/guide/job-schedulers)
- [x] (punted to #211) add job owner ID - e.g. to display job progress to related user, say for imports
- [x] periodically clean up Completed and Failed jobs from database, maybe just log results after deletion?
