### PR TITLE
Catch the error raised by maxResponseSize

### DIFF
--- a/server/cli/db.ts
+++ b/server/cli/db.ts
@@ -15,7 +15,7 @@ export type IAppRequirements = {
   jobsRepository: SqliteJobsRepository;
 };
 
-export default class CliFeeds extends CliAppModule<IAppRequirements> {
+export default class CliDb extends CliAppModule<IAppRequirements> {
   async initCli(program: Command) {
     const { log, app } = this;
     const {


### PR DESCRIPTION
Not sure if this is enough, but it at least prevents the server from bailing out entirely

fixes https://github.com/lmorchard/pebbling-club/issues/214