### PR TITLE
Initial implementation of feeds for profile routes

### DIFF
--- a/client/web/src/css/header.css
+++ b/client/web/src/css/header.css
@@ -26,6 +26,15 @@ header.site > nav {
   gap: var(--column-gap);
 }
 
+header.site > nav a.feed {
+  display: inline-block;
+}
+header.site > nav a.feed svg {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+}
+
 header.site > nav > details > summary {
   position: relative;
   padding: 0;

--- a/common/svg/feed.ts
+++ b/common/svg/feed.ts
@@ -1,0 +1,19 @@
+// see: http://www.feedicons.com/
+export default () => `
+  <svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="128px" height="128px" id="RSSicon" viewBox="0 0 256 256">
+    <defs>
+      <linearGradient x1="0.085" y1="0.085" x2="0.915" y2="0.915" id="RSSg">
+      <stop  offset="0.0" stop-color="#E3702D"/><stop  offset="0.1071" stop-color="#EA7D31"/>
+      <stop  offset="0.3503" stop-color="#F69537"/><stop  offset="0.5" stop-color="#FB9E3A"/>
+      <stop  offset="0.7016" stop-color="#EA7C31"/><stop  offset="0.8866" stop-color="#DE642B"/>
+      <stop  offset="1.0" stop-color="#D95B29"/>
+      </linearGradient>
+    </defs>
+    <rect width="256" height="256" rx="55" ry="55" x="0"  y="0"  fill="#CC5D15"/>
+    <rect width="246" height="246" rx="50" ry="50" x="5"  y="5"  fill="#F49C52"/>
+    <rect width="236" height="236" rx="47" ry="47" x="10" y="10" fill="url(#RSSg)"/>
+    <circle cx="68" cy="189" r="24" fill="#FFF"/>
+    <path d="M160 213h-34a82 82 0 0 0 -82 -82v-34a116 116 0 0 1 116 116z" fill="#FFF"/>
+    <path d="M184 213A140 140 0 0 0 44 73 V 38a175 175 0 0 1 175 175z" fill="#FFF"/>
+  </svg>
+`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "fastify": "^4.28.1",
         "fastify-method-override": "^1.5.10",
         "fastify-plugin": "^4.5.1",
+        "feed": "^4.2.2",
         "feedparser": "^2.2.10",
         "html-get": "^2.16.11",
         "htmlparser2": "^9.1.0",
@@ -5369,6 +5370,18 @@
       "peer": true,
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/feed": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-4.2.2.tgz",
+      "integrity": "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/feedparser": {
@@ -12218,6 +12231,18 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "fastify": "^4.28.1",
     "fastify-method-override": "^1.5.10",
     "fastify-plugin": "^4.5.1",
+    "feed": "^4.2.2",
     "feedparser": "^2.2.10",
     "html-get": "^2.16.11",
     "htmlparser2": "^9.1.0",

--- a/server/web/index.ts
+++ b/server/web/index.ts
@@ -85,6 +85,12 @@ export const configSchema = {
     nullable: true,
     default: null as null | String,
   },
+  siteName: {
+    doc: "Server site name",
+    env: "SITE_NAME",
+    format: String,
+    default: "Pebbling Club",
+  },
   projectDomain: {
     doc: "Glitch.com project domain",
     env: "PROJECT_DOMAIN",

--- a/server/web/profiles.ts
+++ b/server/web/profiles.ts
@@ -1,7 +1,12 @@
 import Boom from "@hapi/boom";
 import templateProfileIndex from "./templates/profile/index";
+import templateProfileFeed, {
+  FeedFormats,
+  constructFeedTitle,
+  constructFeedUrl,
+} from "./templates/profile/feed";
 import { IBaseRouterOptions } from "./types";
-import { FastifyPluginAsync } from "fastify";
+import { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
 import { Profile } from "../services/profiles";
 import { TagCount } from "../services/bookmarks";
 import {
@@ -9,7 +14,6 @@ import {
   parseBookmarkListOptions,
   parseRefreshHeaders,
 } from "./utils/routes";
-import bookmark from "./templates/partials/bookmark";
 
 declare module "fastify" {
   export interface FastifyRequest {
@@ -43,54 +47,153 @@ export const ProfilesRouter: FastifyPluginAsync<
     Params: { username: string };
     Querystring: ListBookmarksQuerystringOptions;
   }>("/:username", async (request, reply) => {
-    const { bookmarks } = options.server.app;
-    const { forceRefresh } = parseRefreshHeaders(request);
-    const bookmarkListOptions = parseBookmarkListOptions(request.query);
-    const viewerId = request.user?.id;
+    return handleProfileRequest(request, reply, options, false);
+  });
 
-    const profile = request.profile as Profile;
-
-    const { total: bookmarksTotal, items: bookmarksItems } =
-      await bookmarks.listForOwner(viewerId, profile.id, bookmarkListOptions);
-
-    return reply.renderTemplate(templateProfileIndex, {
-      ...bookmarkListOptions,
-      profile,
-      forceRefresh,
-      tagCounts: request.tagCounts!,
-      total: bookmarksTotal,
-      bookmarks: bookmarksItems,
-    });
+  fastify.get<{
+    Params: { username: string; format: string };
+    Querystring: ListBookmarksQuerystringOptions;
+  }>("/:username/feed.:format", async (request, reply) => {
+    return handleProfileFeedRequest(request, reply, options, false);
   });
 
   fastify.get<{
     Params: { username: string; tags: string };
     Querystring: ListBookmarksQuerystringOptions;
   }>("/:username/t/:tags", async (request, reply) => {
-    const { bookmarks } = options.server.app;
-    const { forceRefresh } = parseRefreshHeaders(request);
-    const bookmarkListOptions = parseBookmarkListOptions(request.query);
-    const { tags } = request.params;
+    return handleProfileRequest(request, reply, options, true);
+  });
 
-    const viewerId = request.user?.id;
+  fastify.get<{
+    Params: { username: string; tags: string; format: string };
+    Querystring: ListBookmarksQuerystringOptions;
+  }>("/:username/t/:tags/feed.:format", async (request, reply) => {
+    return handleProfileFeedRequest(request, reply, options, true);
+  });
+
+  async function handleProfileRequest(
+    request: FastifyRequest<{
+      Params: { username: string; tags?: string };
+      Querystring: ListBookmarksQuerystringOptions;
+    }>,
+    reply: FastifyReply,
+    options: IProfilesRouterOptions,
+    isTagRequest: boolean
+  ) {
+    const { bookmarks, config } = options.server.app;
+    const { username, tags } = request.params;
     const profile = request.profile as Profile;
+    const { forceRefresh } = parseRefreshHeaders(request);
+    const listOptions = parseBookmarkListOptions(request.query);
 
     const { total: bookmarksTotal, items: bookmarksItems } =
-      await bookmarks.listForOwnerByTags(
-        viewerId,
+      await fetchBookmarks(
+        bookmarks,
+        request.user?.id,
         profile.id,
-        tags.split(/[\+ ]+/g),
-        bookmarkListOptions
+        listOptions,
+        tags
       );
 
-    // TODO: use a different template? allow per-user annotation / description of tag
+    const feedTitle = constructFeedTitle(
+      config.get("siteName"),
+      username,
+      tags
+    );
+
+    const feedUrl = constructFeedUrl(
+      config.get("siteUrl"),
+      username,
+      tags,
+      FeedFormats.rss
+    );
+
     return reply.renderTemplate(templateProfileIndex, {
-      ...bookmarkListOptions,
+      ...listOptions,
       profile,
       forceRefresh,
       tagCounts: request.tagCounts!,
       total: bookmarksTotal,
       bookmarks: bookmarksItems,
+      feedTitle,
+      feedUrl,
     });
-  });
+  }
+
+  const feedContentTypes: Record<FeedFormats, string> = {
+    [FeedFormats.rss]: "application/rss+xml",
+    [FeedFormats.atom]: "application/atom+xml",
+    [FeedFormats.json]: "application/json",
+  };
+
+  async function handleProfileFeedRequest(
+    request: FastifyRequest<{
+      Params: { username: string; format?: string; tags?: string };
+      Querystring: ListBookmarksQuerystringOptions;
+    }>,
+    reply: FastifyReply,
+    options: IProfilesRouterOptions,
+    isTagFeed: boolean
+  ) {
+    const { bookmarks, config } = options.server.app;
+    const { username, format, tags } = request.params;
+    const profile = request.profile as Profile;
+    const listOptions = parseBookmarkListOptions(request.query, {
+      limit: "15",
+    });
+
+    const { items: bookmarksItems } = await fetchBookmarks(
+      bookmarks,
+      request.user?.id,
+      profile.id,
+      listOptions,
+      tags
+    );
+
+    const contentType =
+      feedContentTypes[format as FeedFormats] ||
+      feedContentTypes[FeedFormats.rss];
+
+    const title = constructFeedTitle(config.get("siteName"), username, tags);
+
+    // TODO: need some reverse routing utils to generate these URLs
+    const siteUrl = config.get("siteUrl");
+    const link = new URL(
+      isTagFeed ? `/u/${username}/t/${tags}` : `/u/${username}`,
+      siteUrl
+    ).toString();
+
+    return reply.renderTemplate(
+      templateProfileFeed,
+      {
+        id: isTagFeed ? `u/${username}/t/${tags}` : `u/${username}`,
+        format: FeedFormats[format as keyof typeof FeedFormats],
+        title,
+        bookmarks: bookmarksItems,
+        copyright: "",
+        generator: "Pebbling Club",
+        link,
+      },
+      contentType
+    );
+  }
+
+  async function fetchBookmarks(
+    bookmarksService: any,
+    userId: string | undefined,
+    profileId: string,
+    listOptions: any,
+    tags?: string
+  ) {
+    if (tags) {
+      return bookmarksService.listForOwnerByTags(
+        userId,
+        profileId,
+        tags.split(/[\+ ]+/g),
+        listOptions
+      );
+    } else {
+      return bookmarksService.listForOwner(userId, profileId, listOptions);
+    }
+  }
 };

--- a/server/web/templates/layout.ts
+++ b/server/web/templates/layout.ts
@@ -9,6 +9,7 @@ export interface LayoutProps extends ITemplateProps {
   user?: Profile;
   forceRefresh?: boolean;
   siteUrl?: string;
+  beforeSiteNav?: TemplateContent;
 }
 
 export const layout = ({
@@ -18,6 +19,7 @@ export const layout = ({
   forceRefresh,
   siteUrl,
   htmlHead: htmlHeadIn,
+  beforeSiteNav = "",
   ...pageProps
 }: { content: TemplateContent } & LayoutProps & PageProps) => {
   const newUrl = new URL("/new", siteUrl!).toString();
@@ -60,6 +62,7 @@ export const layout = ({
             </h1>
           </section>
           <nav>
+            ${beforeSiteNav}
             <theme-selector title="Enable dark theme">
               <label>
                 <input type="checkbox" />

--- a/server/web/templates/partials/bookmark.ts
+++ b/server/web/templates/partials/bookmark.ts
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import { BookmarkWithPermissions } from "../../../services/bookmarks";
 import { Profile } from "../../../services/profiles";
 import { html, TemplateContent } from "../../utils/html";
-import linkSvg from "@common/svg/link";
+import svgLink from "@common/svg/link";
 
 export interface Props {
   bookmark: BookmarkWithPermissions;
@@ -34,7 +34,7 @@ export default (props: Props) => {
 
   const thumbnailImage = unfurl?.image
     ? html`<img src="${unfurl.image}" />`
-    : linkSvg;
+    : svgLink;
 
   return html`
     <pc-bookmark bookmark="${bookmarkEncoded}">

--- a/server/web/templates/profile/feed.ts
+++ b/server/web/templates/profile/feed.ts
@@ -1,0 +1,75 @@
+import { BookmarkWithPermissions } from "../../../services/bookmarks";
+import { Profile } from "../../../services/profiles";
+import { Feed, FeedOptions, Item } from "feed";
+
+export enum FeedFormats {
+  rss = "rss",
+  atom = "atom",
+  json = "json",
+}
+
+export interface Props extends FeedOptions {
+  format: FeedFormats;
+  title: string;
+  bookmarks: BookmarkWithPermissions[];
+}
+
+export default ({ format, bookmarks, ...feedOptions }: Props) => {
+  const feed = new Feed({
+    ...feedOptions,
+  });
+
+  for (const bookmark of bookmarks) {
+    const item: Item = {
+      title: bookmark.title,
+      id: bookmark.href,
+      link: bookmark.href,
+      date: new Date(bookmark.created!),
+      description: bookmark.extended,
+    };
+
+    const image = bookmark.meta?.unfurl?.image;
+    if (image) {
+      item.image = image;
+    }
+
+    feed.addItem(item);
+  }
+
+  switch (format) {
+    case FeedFormats.atom:
+      return feed.atom1();
+    case FeedFormats.json:
+      return feed.json1();
+    case FeedFormats.rss:
+    default:
+      return feed.rss2();
+  }
+};
+
+export function constructFeedTitle(
+  siteName: string,
+  username: string,
+  tags: string | undefined
+) {
+  return `${
+    tags
+      ? `${username}'s bookmarks tagged with ${tags}`
+      : `${username}'s bookmarks`
+  } on ${siteName}`;
+}
+
+export function constructFeedUrl(
+  siteUrl: string,
+  username: string,
+  tags: string | undefined,
+  format: FeedFormats
+) {
+  return new URL(
+    // TODO: need some reverse routing utils to generate these URLs
+    tags
+      ? `/u/${username}/t/${tags}/feed.${FeedFormats[format]}`
+      : `/u/${username}/feed.${FeedFormats[format]}`,
+    siteUrl
+  ).toString();
+}

--- a/server/web/templates/profile/index.ts
+++ b/server/web/templates/profile/index.ts
@@ -4,6 +4,8 @@ import { layout, LayoutProps } from "../layout";
 import { BookmarkWithPermissions, TagCount } from "../../../services/bookmarks";
 import { Profile } from "../../../services/profiles";
 
+import svgFeed from "@common/svg/feed";
+
 import partialBookmarkList from "../partials/bookmarkList";
 import partialPaginator from "../partials/paginator";
 
@@ -16,6 +18,8 @@ export interface Props extends LayoutProps {
   limit: number;
   offset: number;
   total: number;
+  feedTitle: string;
+  feedUrl: string;
 }
 
 export default ({
@@ -27,11 +31,21 @@ export default ({
   total,
   limit,
   offset,
+  feedUrl,
+  feedTitle,
   ...locals
 }: Props) => {
   return layout({
     ...locals,
     title: profile.username,
+    htmlHead: html`
+      <link rel="alternate" type="application/rss+xml" title="${feedTitle}" href="${feedUrl}" />
+    `,
+    beforeSiteNav: html`
+      <a href="${feedUrl}" class="feed icon" title="${feedTitle}">
+        ${svgFeed}
+      </a>
+    `,
     content: html`
       <section class="profile">
         <section class="bookmarks">

--- a/server/web/utils/routes.ts
+++ b/server/web/utils/routes.ts
@@ -9,7 +9,11 @@ export type ListBookmarksQuerystringOptions = {
   since?: string;
 };
 
-export function parseBookmarkListOptions(query: ListBookmarksQuerystringOptions) {
+export function parseBookmarkListOptions(
+  queryIn: ListBookmarksQuerystringOptions,
+  defaults: Partial<ListBookmarksQuerystringOptions> = {}
+) {
+  const query = { ...defaults, ...queryIn };
   const limit = parseInt((query.limit as string) || "50", 10);
   const offset = parseInt((query.offset as string) || "0", 10);
   const show = query.show ? query.show.split(",") : undefined;

--- a/server/web/utils/templates.ts
+++ b/server/web/utils/templates.ts
@@ -7,7 +7,8 @@ declare module "fastify" {
   interface FastifyReply {
     renderTemplate: <P extends ITemplateProps>(
       templateFunction: RenderableTemplate<P>,
-      props?: P
+      props?: P,
+      contentType?: string
     ) => void;
   }
 }
@@ -18,29 +19,32 @@ export interface TemplateRendererOptions {
 
 export const TemplateRenderer = fp(
   async (fastify, { config }: TemplateRendererOptions) => {
-    fastify.decorateReply("renderTemplate", function (template, props) {
-      const reply = this;
-      const request = this.request;
+    fastify.decorateReply(
+      "renderTemplate",
+      function (template, props, contentType = "text/html") {
+        const reply = this;
+        const request = this.request;
 
-      const layoutProps: LayoutProps = {
-        user: request.user,
-        siteUrl: config.get("siteUrl"),
-      };
+        const layoutProps: LayoutProps = {
+          user: request.user,
+          siteUrl: config.get("siteUrl"),
+        };
 
-      return reply
-        .code(200)
-        .headers({
-          "Content-Type": "text/html",
-          "Access-Control-Allow-Origin": "*",
-        })
-        .send(
-          render(
-            template({
-              ...layoutProps,
-              ...props,
-            })
-          )
-        );
-    });
+        return reply
+          .code(200)
+          .headers({
+            "Content-Type": contentType,
+            "Access-Control-Allow-Origin": "*",
+          })
+          .send(
+            render(
+              template({
+                ...layoutProps,
+                ...props,
+              })
+            )
+          );
+      }
+    );
   }
 );


### PR DESCRIPTION
todo:

- [x] add a feeds template for profile bookmark list pages
- [x] serve up feeds as alternatives to profile pages
- [x] use the correct content-type header per feed format
- [x] link to feeds from profile pages with RSS icon
- [x] add autodiscovery metadata to page head
- [x] flesh out the feed metadata (author, link, etc)
- [x] polish the feed items
- [x] support 304 status conditional get (deferred to https://github.com/lmorchard/pebbling-club/issues/228)

fixes https://github.com/lmorchard/pebbling-club/issues/23